### PR TITLE
Add notes about Context 7 and a small clarification in README

### DIFF
--- a/src/kx13-codebase-migration/README.md
+++ b/src/kx13-codebase-migration/README.md
@@ -1,6 +1,6 @@
 # KX13 Project codebase migration
 
-AI-assistant prompts for migrating the **codebase** of Kentico Xperience 13 projects to [Xperience by Kentico](https://docs.kentico.com/x/migrate_from_kx13_guides).
+AI-assistant example prompts for migrating the **codebase** of Kentico Xperience 13 projects to [Xperience by Kentico](https://docs.kentico.com/x/migrate_from_kx13_guides).
 
 ## Scope
 
@@ -25,6 +25,9 @@ See the [Adjust and adapt your code](https://docs.kentico.com/x/migrate_your_cod
 - Kentico Xperience 13 project (source).
 - Xperience by Kentico project (target) connected to a database migrated using the [Kentico Migration Tool](https://github.com/Kentico/xperience-by-kentico-kentico-migration-tool). The prompts were tested on a fresh Xperience by Kentico project created using the `kentico-xperience-mvc` [project template](https://docs.kentico.com/x/DQKQC).
 - AI coding assistant installed (for example: GitHub Copilot, Cursor, Claude Code).
+
+> [!NOTE]
+> We've released a [Kentico Xperience 13 library on Context7](https://context7.com/websites/kentico_13) that you can use to look up KX13 API references and code samples when working on code migration. Note that Context7 is a third-party service not maintained or supported by Kentico, so your experience may vary.
 
 ## Usage
 


### PR DESCRIPTION
Updated the README to:
- mention the KX13 Context 7
- clarify that the prompts are examples for migrating the codebase.

Review promised by @JakubS-Kentico 
