### PR TITLE
Feature: Configure CD Repository plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI agent skills, instructions, and workflows for Xperience by Kentico development",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -42,7 +42,7 @@
       "name": "configure-cd-repository",
       "source": "./plugins/configure-cd-repository",
       "description": "Skills for configuring scoped CD Repository filters from CI Repository changes in Xperience by Kentico",
-      "version": "1.0.1",
+      "version": "1.0.0",
       "author": {
         "name": "Kentico"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,6 +37,20 @@
       "license": "MIT",
       "keywords": ["kentico", "xperience", "migration", "kx13", "cms"],
       "strict": false
+    },
+    {
+      "name": "configure-cd-repository",
+      "source": "./plugins/configure-cd-repository",
+      "description": "Skills for discovering project layout and configuring scoped CD Repository filters from CI Repository changes in Xperience by Kentico",
+      "version": "1.0.0",
+      "author": {
+        "name": "Kentico"
+      },
+      "homepage": "https://github.com/Kentico/xperience-by-kentico-kenticopilot/tree/main/plugins/configure-cd-repository",
+      "repository": "https://github.com/Kentico/xperience-by-kentico-kenticopilot",
+      "license": "MIT",
+      "keywords": ["kentico", "xperience", "cd-repository", "continuous-deployment", "cms"],
+      "strict": false
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -41,15 +41,15 @@
     {
       "name": "configure-cd-repository",
       "source": "./plugins/configure-cd-repository",
-      "description": "Skills for discovering project layout and configuring scoped CD Repository filters from CI Repository changes in Xperience by Kentico",
-      "version": "1.0.0",
+      "description": "Skills for configuring scoped CD Repository filters from CI Repository changes in Xperience by Kentico",
+      "version": "1.0.1",
       "author": {
         "name": "Kentico"
       },
       "homepage": "https://github.com/Kentico/xperience-by-kentico-kenticopilot/tree/main/plugins/configure-cd-repository",
       "repository": "https://github.com/Kentico/xperience-by-kentico-kenticopilot",
       "license": "MIT",
-      "keywords": ["kentico", "xperience", "cd-repository", "continuous-deployment", "cms"],
+      "keywords": ["kentico", "xperience", "ci/cd", "continuous-deployment", "cms"],
       "strict": false
     }
   ]

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -39,15 +39,15 @@
     {
       "name": "configure-cd-repository",
       "source": "./configure-cd-repository",
-      "description": "Skills for discovering project layout and configuring scoped CD Repository filters from CI Repository changes in Xperience by Kentico",
-      "version": "1.0.0",
+      "description": "Skills for configuring scoped CD Repository filters from CI Repository changes in Xperience by Kentico",
+      "version": "1.0.1",
       "author": {
         "name": "Kentico"
       },
       "homepage": "https://github.com/Kentico/xperience-by-kentico-kenticopilot/tree/main/plugins/configure-cd-repository",
       "repository": "https://github.com/Kentico/xperience-by-kentico-kenticopilot",
       "license": "MIT",
-      "keywords": ["kentico", "xperience", "cd-repository", "continuous-deployment", "cms"]
+      "keywords": ["kentico", "xperience", "ci/cd", "continuous-deployment", "cms"]
     }
   ]
 }

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "xperience-by-kentico-kenticopilot",
   "metadata": {
     "description": "AI agent skills, instructions, and workflows for Xperience by Kentico development",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "pluginRoot": "./plugins"
   },
   "owner": {
@@ -40,7 +40,7 @@
       "name": "configure-cd-repository",
       "source": "./configure-cd-repository",
       "description": "Skills for configuring scoped CD Repository filters from CI Repository changes in Xperience by Kentico",
-      "version": "1.0.1",
+      "version": "1.0.0",
       "author": {
         "name": "Kentico"
       },

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -35,6 +35,19 @@
       "repository": "https://github.com/Kentico/xperience-by-kentico-kenticopilot",
       "license": "MIT",
       "keywords": ["kentico", "xperience", "migration", "kx13", "cms"]
+    },
+    {
+      "name": "configure-cd-repository",
+      "source": "./configure-cd-repository",
+      "description": "Skills for discovering project layout and configuring scoped CD Repository filters from CI Repository changes in Xperience by Kentico",
+      "version": "1.0.0",
+      "author": {
+        "name": "Kentico"
+      },
+      "homepage": "https://github.com/Kentico/xperience-by-kentico-kenticopilot/tree/main/plugins/configure-cd-repository",
+      "repository": "https://github.com/Kentico/xperience-by-kentico-kenticopilot",
+      "license": "MIT",
+      "keywords": ["kentico", "xperience", "cd-repository", "continuous-deployment", "cms"]
     }
   ]
 }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+	"servers": {
+		"kentico-docs-mcp": {
+			"type": "http",
+			"url": "https://docs.kentico.com/mcp"
+		}
+	},
+	"inputs": []
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This repository contains plugins (skills, instructions, MCP server configuration
 
 Skills are transferable to other solutions. Follow the conventions of your specific assistant.
 
-
 ## Available plugins
 
 This repository provides plugins, each containing a set of skills for AI coding assistants. See the plugin README files for full details.
@@ -24,9 +23,9 @@ This repository provides plugins, each containing a set of skills for AI coding 
 
 Two-stage workflow for building [Page Builder](https://docs.kentico.com/x/6QWiCQ) widgets. The AI first researches your requirements against your project structure and the Xperience documentation, then generates the full widget implementation (view component, properties, Razor view, view model, localization). Full instructions are available in the [README](./plugins/widget-creation/README.md).
 
-| Skill | Description |
-|---|---|
-| `widget-create-research` | Analyzes requirements and design files, generates implementation instructions |
+| Skill                          | Description                                                                      |
+| ------------------------------ | -------------------------------------------------------------------------------- |
+| `widget-create-research`       | Analyzes requirements and design files, generates implementation instructions    |
 | `widget-create-implementation` | Creates widget code following the generated instructions and project conventions |
 
 ### KX13 codebase migration
@@ -35,13 +34,24 @@ Two-stage workflow for building [Page Builder](https://docs.kentico.com/x/6QWiCQ
 
 AI-assisted migration of Kentico Xperience 13 live-site code (pages, widgets, shared components) to Xperience by Kentico. Full instructions are available in the [README](./plugins/kx13-codebase-migration/README.md).
 
-| Skill | Description |
-|---|---|
-| `migrate-global-code` | Sets up the Xperience by Kentico project foundation (code generation, localization, routing, Page Builder) |
-| `migrate-page` | Migrates a page's controller, views, repositories, and dependencies |
-| `migrate-page-widgets` | Migrates Page Builder widgets and sections for a specified page |
-| `migrate-shared-component` | Migrates reusable components (header, footer, etc.) with dependencies |
-| `migrate-page-visual` | Compares old and new pages visually with Playwright, fixes discrepancies |
+| Skill                      | Description                                                                                                |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `migrate-global-code`      | Sets up the Xperience by Kentico project foundation (code generation, localization, routing, Page Builder) |
+| `migrate-page`             | Migrates a page's controller, views, repositories, and dependencies                                        |
+| `migrate-page-widgets`     | Migrates Page Builder widgets and sections for a specified page                                            |
+| `migrate-shared-component` | Migrates reusable components (header, footer, etc.) with dependencies                                      |
+| `migrate-page-visual`      | Compares old and new pages visually with Playwright, fixes discrepancies                                   |
+
+### Configure CD Repository
+
+> **Location:** [plugins/configure-cd-repository/](./plugins/configure-cd-repository/)
+
+Two-stage workflow for building scoped [Continuous Deployment Repository](https://docs.kentico.com/x/continuous_deployment) filters from CI Repository changes. The AI first discovers your project layout and tooling, then inspects changed CI Repository files from specified PRs or commit ranges and writes a minimal `IncludedObjectTypes` / `ObjectFilters` allowlist — automatically excluding noise from Xperience version updates. Full instructions are available in the [README](./plugins/configure-cd-repository/README.md).
+
+| Skill                     | Description                                                                                          |
+| ------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `cd-repository-discover`  | Locates the Xperience app, CI/CD repository paths, and git tooling; saves context to a reusable file |
+| `cd-repository-configure` | Reads the context file and PR/commit changes, then writes a scoped `repository.config`               |
 
 ## Requirements
 
@@ -58,11 +68,11 @@ This repository is an [agent plugin marketplace](https://code.visualstudio.com/d
 
 1. Add the marketplace to your VS Code settings (`settings.json`):
 
-    ```json
-    "chat.plugins.marketplaces": [
-        "Kentico/xperience-by-kentico-kenticopilot"
-    ]
-    ```
+   ```json
+   "chat.plugins.marketplaces": [
+       "Kentico/xperience-by-kentico-kenticopilot"
+   ]
+   ```
 
 2. Open the Extensions sidebar and search `@agentPlugins` to browse and install available plugins.
 
@@ -72,6 +82,7 @@ This repository is an [agent plugin marketplace](https://code.visualstudio.com/d
 copilot plugin marketplace add Kentico/xperience-by-kentico-kenticopilot
 copilot plugin install widget-creation@xperience-by-kentico-kenticopilot
 copilot plugin install kx13-codebase-migration@xperience-by-kentico-kenticopilot
+copilot plugin install configure-cd-repository@xperience-by-kentico-kenticopilot
 ```
 
 ### Claude Code
@@ -80,6 +91,7 @@ copilot plugin install kx13-codebase-migration@xperience-by-kentico-kenticopilot
 /plugin marketplace add Kentico/xperience-by-kentico-kenticopilot
 /plugin install widget-creation@xperience-by-kentico-kenticopilot
 /plugin install kx13-codebase-migration@xperience-by-kentico-kenticopilot
+/plugin install configure-cd-repository@xperience-by-kentico-kenticopilot
 ```
 
 For more details, see the [Usage Guide](./docs/Usage-Guide.md).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Two-stage workflow for building scoped [Continuous Deployment Repository](https:
 
 | Skill                     | Description                                                                                          |
 | ------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `cd-repository-discover`  | Locates the Xperience app, CI/CD repository paths, and git tooling; saves context to a reusable file |
+| `cd-repository-discovery` | Locates the Xperience app, CI/CD repository paths, and git tooling; saves context to a reusable file |
 | `cd-repository-configure` | Reads the context file and PR/commit changes, then writes a scoped `repository.config`               |
 
 ## Requirements

--- a/plugins/configure-cd-repository/.mcp.json
+++ b/plugins/configure-cd-repository/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "kentico.docs.mcp": {
+      "type": "http",
+      "url": "https://docs.kentico.com/mcp"
+    }
+  }
+}

--- a/plugins/configure-cd-repository/README.md
+++ b/plugins/configure-cd-repository/README.md
@@ -1,0 +1,138 @@
+# Configure CD Repository
+
+AI-assisted skills for configuring the [Continuous Deployment (CD) Repository](https://docs.kentico.com/x/continuous_deployment) in Xperience by Kentico. The skills discover your project layout, inspect CI Repository changes from one or more pull requests or commit ranges, and produce a scoped `repository.config` that captures only your feature changes — while automatically excluding noise from Xperience version updates.
+
+## Workflow
+
+These skills provide two-stage assistance for building CD Repository filters:
+
+1. **Discovery stage** – Locates the Xperience app folder, CI and CD Repository paths, and available git tooling. Saves everything to a reusable context file so you don't have to re-enter paths for every deployment.
+2. **Configure stage** – Reads the context file, collects changed CI Repository files from the specified PRs or commit range, classifies them (feature vs. Xperience-update noise), and writes a minimal `IncludedObjectTypes` / `ObjectFilters` allowlist to `repository.config`.
+
+## Prerequisites
+
+- Xperience by Kentico project with CI/CD Repository enabled
+- AI coding assistant installed (for example, GitHub Copilot or Claude Code)
+- `gh` CLI (recommended) or local `git` available in your terminal
+
+## Install the plugin
+
+### VS Code (GitHub Copilot)
+
+Add the marketplace to your VS Code settings (`settings.json`), then browse and install from the Extensions sidebar (`@agentPlugins`):
+
+```json
+"chat.plugins.marketplaces": [
+    "Kentico/xperience-by-kentico-kenticopilot"
+]
+```
+
+For more information, see: [VS Code plugin marketplace](https://code.visualstudio.com/docs/copilot/customization/agent-plugins#_configure-plugin-marketplaces)
+
+### Copilot CLI
+
+```bash
+copilot plugin marketplace add Kentico/xperience-by-kentico-kenticopilot
+copilot plugin install configure-cd-repository@xperience-by-kentico-kenticopilot
+```
+
+### Claude Code
+
+```bash
+/plugin marketplace add Kentico/xperience-by-kentico-kenticopilot
+/plugin install configure-cd-repository@xperience-by-kentico-kenticopilot
+```
+
+## Usage
+
+### 1. Run the discovery stage
+
+The discovery skill finds your Xperience app path, CI and CD Repository locations, and detects whether `gh` or local `git` should be used to retrieve change information. It writes this context to a `cd-repository-context.json` file in a folder you specify.
+
+You only need to run this once per project (or after your project structure changes).
+
+#### VS Code GitHub Copilot example
+
+```text
+/cd-repository-discover
+
+Save context to: C:/my-project/.cd-context
+```
+
+The skill will ask for any values it cannot discover automatically (for example, the Xperience app path if multiple candidates exist in the workspace).
+
+### 2. Run the configure stage
+
+Provide the folder containing the context file written in step 1, along with the PR numbers or git commit range you want to deploy.
+
+#### VS Code GitHub Copilot example — single PR
+
+```text
+/cd-repository-configure
+
+Context folder: C:/my-project/.cd-context
+Changes: PR 312
+```
+
+#### VS Code GitHub Copilot example — multiple PRs
+
+```text
+/cd-repository-configure
+
+Context folder: C:/my-project/.cd-context
+Changes: PR 310, PR 311, PR 312
+```
+
+#### VS Code GitHub Copilot example — commit range
+
+```text
+/cd-repository-configure
+
+Context folder: C:/my-project/.cd-context
+Changes: abc1234..def5678
+```
+
+The skill will:
+
+- Filter changed files to only those inside the CI Repository
+- Classify them as feature changes or Xperience update-only changes
+- Exclude Xperience update-only changes from the deployment filters (unless you ask to include them)
+- Write a minimal `IncludedObjectTypes` allowlist and scoped `ObjectFilters` to `repository.config`
+- Diff and explain every change it makes
+
+## Prompt output
+
+The configure stage produces an updated `repository.config` containing:
+
+- `IncludedObjectTypes` — allowlist of only the object types touched by your feature changes
+- `ObjectFilters` with `IncludedCodeNames` — precise code name scope per object type
+
+It also prints a deployment summary covering reviewed change selectors, selected object types and code names, excluded update-only groups and the reason for exclusion, and a diff of exactly what changed in `repository.config`.
+
+If `Export-DeploymentPackage.ps1` is present in the repository, the skill runs it and validates that the exported package contains the expected scoped content.
+
+## Best practices
+
+- Re-run **discovery** whenever your project structure changes or you move to a new machine.
+- Use the **same context folder** across multiple configure runs for the same project so you never have to re-enter paths.
+- Keep Xperience version-update PRs separate from feature PRs where possible — this makes classification unambiguous and exclusion automatic.
+- Review the generated `repository.config` diff before deploying, especially for the first run on a project.
+- Commit `cd-repository-context.json` to your repository if your team shares the same project layout, so teammates can skip the discovery stage.
+
+## Skill reference
+
+### cd-repository-discover
+
+Skill name: **cd-repository-discover**
+
+Discovers the Xperience app path, CI Repository path, CD `repository.config` path, git repository root, and tooling availability (`gh` / `git`). Saves all values to `cd-repository-context.json` in the folder you provide.
+
+**Argument hint:** Path to a folder where the discovery context should be written.
+
+### cd-repository-configure
+
+Skill name: **cd-repository-configure**
+
+Reads `cd-repository-context.json` and a set of change selectors (PR numbers and/or a commit range), collects CI Repository file changes, excludes Xperience update noise, and writes a scoped CD Repository configuration.
+
+**Argument hint:** Path to the discovery context folder and PR number(s) or commit hash range.

--- a/plugins/configure-cd-repository/README.md
+++ b/plugins/configure-cd-repository/README.md
@@ -4,10 +4,11 @@ AI-assisted skills for configuring the [Continuous Deployment (CD) Repository](h
 
 ## Workflow
 
-These skills provide two-stage assistance for building CD Repository filters:
+These skills provide three-stage assistance for building CD Repository filters:
 
-1. **Discovery stage** – Locates the Xperience app folder, CI and CD Repository paths, and available git tooling. Saves everything to a reusable context file so you don't have to re-enter paths for every deployment.
-2. **Configure stage** – Reads the context file, collects changed CI Repository files from the specified PRs or commit range, classifies them (feature vs. Xperience-update noise), and writes a minimal `IncludedObjectTypes` / `ObjectFilters` allowlist to `repository.config`.
+1. **Discovery stage** – Locates the Xperience app folder, CI and CD Repository paths, and available git tooling. Detects the `repository.config` syntax version. Saves everything to a reusable context file so you don't have to re-enter paths for every deployment.
+2. **Upgrade stage** (if needed) – If discovery detects a legacy v1 `repository.config`, migrates it to v2 syntax to enable advanced content item filtering and improved CD restore performance. Automatically updates the context file when complete.
+3. **Configure stage** – Reads the context file, collects changed CI Repository files from the specified PRs or commit range, classifies them (feature vs. Xperience-update noise), and writes a minimal `IncludedObjectTypes` / `ObjectFilters` allowlist to `repository.config`.
 
 ## Prerequisites
 
@@ -47,7 +48,7 @@ copilot plugin install configure-cd-repository@xperience-by-kentico-kenticopilot
 
 ### 1. Run the discovery stage
 
-The discovery skill finds your Xperience app path, CI and CD Repository locations, and detects whether `gh` or local `git` should be used to retrieve change information. It writes this context to a `cd-repository-context.json` file in a folder you specify.
+The discovery skill finds your Xperience app path, CI and CD Repository locations, and detects whether `gh` or local `git` should be used to retrieve change information. It also detects the current `repository.config` syntax version. It writes this context to a `cd-repository-context.json` file in a folder you specify.
 
 You only need to run this once per project (or after your project structure changes).
 
@@ -59,9 +60,31 @@ You only need to run this once per project (or after your project structure chan
 Save context to: C:/my-project/.cd-context
 ```
 
-The skill will ask for any values it cannot discover automatically (for example, the Xperience app path if multiple candidates exist in the workspace).
+The skill will ask for any values it cannot discover automatically (for example, the Xperience app path if multiple candidates exist in the workspace). It will also report the `repository.config` syntax version detected.
 
-### 2. Run the configure stage
+### 2. Upgrade config syntax (if needed)
+
+If discovery detected a legacy v1 `repository.config`, upgrade it to v2 first to enable advanced content item filtering and improve CD restore performance.
+
+#### VS Code GitHub Copilot example — with explicit config path
+
+```text
+/cd-repository-upgrade
+
+Repository config path: C:/my-project/App_Data/CDRepository/repository.config
+```
+
+#### VS Code GitHub Copilot example — auto-discover from context
+
+If you've already run `cd-repository-discovery`, you can run the upgrade skill without arguments and it will automatically locate the config file from the context file:
+
+```text
+/cd-repository-upgrade
+```
+
+The skill will create a backup (`repository.config.v1.backup`) and migrate the file to v2 syntax. If it discovered the config from a context file, it will automatically update the context to reflect v2 syntax. Proceed to step 3 (configure stage).
+
+### 3. Run the configure stage
 
 Provide the folder containing the context file written in step 1, along with the PR numbers or git commit range you want to deploy.
 
@@ -117,9 +140,19 @@ If `Export-DeploymentPackage.ps1` is present in the repository, the skill runs i
 - Use the **same context folder** across multiple configure runs for the same project so you never have to re-enter paths.
 - Keep Xperience version-update PRs separate from feature PRs where possible — this makes classification unambiguous and exclusion automatic.
 - Review the generated `repository.config` diff before deploying, especially for the first run on a project.
-- Commit `cd-repository-context.json` to your repository if your team shares the same project layout, so teammates can skip the discovery stage.
+- Keep the generated `cd-repository-context.json` local to your machine because it contains absolute, machine-specific paths. Optionally add the context folder to `.gitignore`. If you want to share the expected context structure with teammates, commit a template or example context file instead of the generated one.
 
 ## Skill reference
+
+### cd-repository-upgrade
+
+Skill name: **cd-repository-upgrade**
+
+Migrates a CD Repository `repository.config` file from legacy v1 syntax to v2 syntax, enabling advanced content item filtering and improved CD restore performance. Creates a backup (`repository.config.v1.backup`) before migration.
+
+**Argument hint:** Path to the `repository.config` file to migrate.
+
+**Use when:** After running discovery, if `repository.config` syntax version is reported as v1. Run before `cd-repository-configure` to ensure your configuration uses the v2 format. See [Migrate CI/CD repository.config to v2](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/configure-ci-cd-repositories/config-v2-migration) for details on the v1 to v2 changes.
 
 ### cd-repository-discovery
 

--- a/plugins/configure-cd-repository/README.md
+++ b/plugins/configure-cd-repository/README.md
@@ -54,7 +54,7 @@ You only need to run this once per project (or after your project structure chan
 #### VS Code GitHub Copilot example
 
 ```text
-/cd-repository-discover
+/cd-repository-discovery
 
 Save context to: C:/my-project/.cd-context
 ```
@@ -121,9 +121,9 @@ If `Export-DeploymentPackage.ps1` is present in the repository, the skill runs i
 
 ## Skill reference
 
-### cd-repository-discover
+### cd-repository-discovery
 
-Skill name: **cd-repository-discover**
+Skill name: **cd-repository-discovery**
 
 Discovers the Xperience app path, CI Repository path, CD `repository.config` path, git repository root, and tooling availability (`gh` / `git`). Saves all values to `cd-repository-context.json` in the folder you provide.
 

--- a/plugins/configure-cd-repository/README.md
+++ b/plugins/configure-cd-repository/README.md
@@ -108,11 +108,31 @@ Changes: PR 310, PR 311, PR 312
 
 #### VS Code GitHub Copilot example — commit range
 
+The `..` range operator follows standard git syntax: the start commit is **exclusive** and the end commit is **inclusive**. Use the commit just before your first feature commit as the start of the range.
+
 ```text
 /cd-repository-configure
 
 Context folder: C:/my-project/.cd-context
 Changes: abc1234..def5678
+```
+
+To include `abc1234` itself, use its parent (`abc1234^`) as the range start:
+
+```text
+/cd-repository-configure
+
+Context folder: C:/my-project/.cd-context
+Changes: abc1234^..def5678
+```
+
+To deploy exactly one commit in isolation:
+
+```text
+/cd-repository-configure
+
+Context folder: C:/my-project/.cd-context
+Changes: abc1234^..abc1234
 ```
 
 The skill will:

--- a/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: cd-repository-configure
+description: "Builds or updates CD Repository filters from CI Repository changes using a discovery context file and PR numbers or commit ranges, while excluding Xperience update-only noise by default."
+argument-hint: "Path to discovery context folder and PR number(s) or commit hash range"
+compatibility: "Works with GitHub CLI or local git"
+---
+
+You are tasked with creating a scoped CD Repository configuration from CI Repository changes.
+
+## Input Parameters
+
+- **Context Folder Path** - Folder that contains `cd-repository-context.json` produced by `cd-repository-discover`.
+- **Change Selectors** - One or more PR numbers and/or one git commit range (for example `abc123..def456`).
+
+## Prerequisite
+
+Read `cd-repository-context.json` from the provided folder and validate:
+
+- `appPath`
+- `repositoryRoot`
+- `ciRepositoryPath`
+- `cdRepositoryConfigPath`
+- `tooling.preferredChangeSource`
+
+If the context file is missing or invalid, stop and ask the user to run `cd-repository-discover` (or fix the file).
+
+## Workflow
+
+1. Load discovery context and confirm paths still exist.
+2. Resolve change source strategy:
+   - Prefer `gh` when context says `gh-pr` and `gh` is available.
+   - Otherwise use local git commands.
+3. Collect changed files for each selector:
+   - PR mode: collect file list from each PR.
+   - Commit range mode: run `git diff --name-only` from `repositoryRoot`.
+4. Keep only files under `ciRepositoryPath`.
+5. Classify CI changes into:
+   - **Business/feature changes** (include in deployment filtering)
+   - **Xperience update-only changes** (exclude by default)
+6. Exclude update-only changes unless user explicitly requests inclusion.
+7. Map remaining CI paths to object types and code names.
+8. Update `cdRepositoryConfigPath`:
+   - Build minimal `IncludedObjectTypes` allowlist (main object types only).
+   - Add/merge `ObjectFilters` with one `IncludedCodeNames` entry per object type using semicolon-separated code names.
+   - Preserve existing `RestoreMode` unless user asks to change it.
+9. Validate XML and remove duplicate/contradicting filters.
+10. Diff and explain exact changes.
+11. If available in the repository, run deployment package export validation (`Export-DeploymentPackage.ps1`) and verify expected scoped output.
+
+## Change Classification Guidance
+
+Treat changes as **Xperience update-only** when they originate from platform/package update work (for example hotfix/version bump PRs or commits) and do not represent intentional business configuration/content modeling changes.
+
+Common signals:
+
+- PR/commit title or description indicates Xperience update, hotfix, NuGet/package bump, or version migration.
+- Bulk CI churn tied to upgrade commits with no explicit feature intent.
+
+When uncertain, default to safety:
+
+- Exclude ambiguous update-related groups.
+- Report exclusions clearly so user can opt in.
+
+## Mapping Hints
+
+Common CI paths to object types:
+
+- `@global/cms.contenttype` -> `cms.contenttype`
+- `@global/cms.user` -> `cms.systemtable`
+- `@global/cms.member` -> `cms.systemtable`
+- `@global/cms.contact` -> `cms.systemtable`
+- `@global/cms.class` -> `cms.class`
+- `@global/emaillibrary.emailtemplate` -> `emaillibrary.emailtemplate`
+- `@global/cms.settingskey` -> `cms.settingskey`
+- `*/contentitemdata.*` or `*/cms.contentitemcommondata*` -> content item related (include only when intentionally in deployment scope)
+
+## Decision Rules
+
+- If `IncludedObjectTypes` is populated, it is an allowlist: include every required main object type.
+- Child and binding objects follow parent inclusion rules.
+- Prefer explicit object types over broad `IncludeAll` patterns.
+- Add content-item-specific filters only when content item deployment is intentionally requested.
+- Keep code name filters minimal and precise.
+
+## Quality Checks
+
+- XML is well-formed.
+- No repeated `IncludedCodeNames` entries for the same object type.
+- Code names match actual CI object code names from XML files.
+- Update-only groups are excluded (unless user opted in).
+- Final config diff is concise and justified.
+
+## Output Format
+
+Finish with a concise deployment summary:
+
+- Reviewed source selectors (PRs / commit range)
+- Selected object types for deployment
+- Selected code names by object type
+- Explicitly excluded update-only groups and why
+- Exact impact on `repository.config`
+- Validation result for deployment package export (if executed)

--- a/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
@@ -12,7 +12,7 @@ You are tasked with creating a scoped CD Repository configuration from CI Reposi
 - **Context Folder Path** - Folder that contains `cd-repository-context.json` produced by `cd-repository-discovery`.
 - **Change Selectors** - Provide **either** PR number(s) **or** a git commit range (not both):
   - **PR mode:** One or more PR numbers (e.g., `PR 312` or `PR 310, PR 311, PR 312`)
-  - **Commit mode:** One git commit range (e.g., `abc123..def456`) which is inclusive
+  - **Commit mode:** One git commit range (e.g., `abc123..def456` or `abc123^..def456`)
 
 Choose PR mode when deploying specific, discrete changes; choose commit mode when deploying all changes between two commits.
 

--- a/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
@@ -10,7 +10,11 @@ You are tasked with creating a scoped CD Repository configuration from CI Reposi
 ## Input Parameters
 
 - **Context Folder Path** - Folder that contains `cd-repository-context.json` produced by `cd-repository-discovery`.
-- **Change Selectors** - One or more PR numbers and/or one git commit range (for example `abc123..def456`).
+- **Change Selectors** - Provide **either** PR number(s) **or** a git commit range (not both):
+  - **PR mode:** One or more PR numbers (e.g., `PR 312` or `PR 310, PR 311, PR 312`)
+  - **Commit mode:** One git commit range (e.g., `abc123..def456`)
+
+Choose PR mode when deploying specific, discrete changes; choose commit mode when deploying all changes between two commits.
 
 ## Prerequisite
 
@@ -46,10 +50,13 @@ If the context file is missing or invalid, stop and ask the user to run `cd-repo
 8. Update `cdRepositoryConfigPath`:
    - Build minimal `IncludedObjectTypes` allowlist (main object types only).
    - Add/merge `ObjectFilters` with one `IncludedCodeNames` entry per object type using semicolon-separated code names.
-   - Preserve existing `RestoreMode` unless user asks to change it.
+   - **Determine RestoreMode:**
+     - Analyze git history: if **all** CI `.xml` files under `ciRepositoryPath` are **new** (created), use `Create` mode for better performance.
+     - If **any** CI `.xml` files are **modified** (updated), use `CreateUpdate` mode to preserve existing objects.
+     - **Note:** Create mode has significant performance benefits, especially for content item deployments. Use CreateUpdate only when necessary for file updates.
 9. Validate XML and remove duplicate/contradicting filters.
 10. Diff and explain exact changes.
-11. If available in the repository, run deployment package export validation (`Export-DeploymentPackage.ps1`) and verify expected scoped output.
+11. If available in the repository, run `Export-DeploymentPackage.ps1` to generate the deployment package. **Manually verify** that the generated package contains the expected scoped objects. (The script copies your CD Repository into the package; it does not validate CD filters.)
 
 ## Change Classification Guidance
 
@@ -70,13 +77,41 @@ When uncertain, default to safety:
 Common CI paths to object types:
 
 - `@global/cms.contenttype` -> `cms.contenttype`
-- `@global/cms.user` -> `cms.systemtable`
+- `@global/cms.user` -> `cms.systemtable` *(unintuitive: folder is `cms.user` but config uses `cms.systemtable`)*
 - `@global/cms.member` -> `cms.systemtable`
 - `@global/cms.contact` -> `cms.systemtable`
-- `@global/cms.class` -> `cms.class`
+- `@global/cms.class` -> `cms.class` *(see note below about ambiguity)*
 - `@global/emaillibrary.emailtemplate` -> `emaillibrary.emailtemplate`
-- `@global/cms.settingskey` -> `cms.settingskey`
-- `*/contentitemdata.*` or `*/cms.contentitemcommondata*` -> content item related (include only when intentionally in deployment scope)
+- `@global/cms.settingskey` -> `cms.settingskey` *(excluded from CI/CD by default due to potentially sensitive data; flag this to the user if it appears in a diff)*
+
+**Channel-scoped content (pages, emails, headless items):** These are stored under `<ChannelName>/` rather than `@global/`. For example, `DancingGoat/cms.contentitem/` contains pages for the DancingGoat website channel. When these paths appear in CI changes, use `IncludedContentItemsOfType` / `ContentItemFilters` (v2) rather than `ObjectFilters`. See [CI/CD object type reference](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/reference-ci-cd-object-types#content-management) for details.
+
+**Forms require two object types:** Both `@global/cms.form/` and `@global/cms.formclass/` must be included together. The `cms.formclass` files use a `bizform.` code name prefix (e.g., `bizform.userfeedback.xml`). Include both in `IncludedObjectTypes`:
+
+  ```xml
+  <IncludedObjectTypes>
+    <ObjectType>cms.form</ObjectType>
+    <ObjectType>cms.formclass</ObjectType>
+  </IncludedObjectTypes>
+  ```
+
+**`@global/cms.class` ambiguity:** This folder covers both module class definitions and reusable field schema definitions. Inspect the file code names to determine which is present before scoping `ObjectFilters`.
+
+**Reusable field schemas** -> Object type `cms.class`. Reusable field schema definitions are tracked via the `CMS.ContentItemCommonData` code name. To include them, add both an `IncludedObjectTypes` entry and an `ObjectFilters` entry:
+
+  ```xml
+  <IncludedObjectTypes>
+    <ObjectType>cms.class</ObjectType>
+  </IncludedObjectTypes>
+  <ObjectFilters>
+    <!-- Contains reusable field schema definitions -->
+    <IncludedCodeNames ObjectType="cms.class">
+      CMS.ContentItemCommonData
+    </IncludedCodeNames>
+  </ObjectFilters>
+  ```
+
+  See [CI/CD object type reference](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/reference-ci-cd-object-types#content-management) for details.
 
 ## Decision Rules
 
@@ -102,5 +137,10 @@ Finish with a concise deployment summary:
 - Selected object types for deployment
 - Selected code names by object type
 - Explicitly excluded update-only groups and why
+- Determined RestoreMode and reasoning (Create vs. CreateUpdate based on git history)
 - Exact impact on `repository.config`
 - Validation result for deployment package export (if executed)
+
+## Leveraging Kentico Documentation
+
+This skill has access to the Kentico Docs MCP server. If you need deeper information on any topic (content item filtering, CD Repository configuration, object types, etc.), reference the [CI/CD documentation](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/) to provide more accurate and detailed guidance.

--- a/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
@@ -9,7 +9,7 @@ You are tasked with creating a scoped CD Repository configuration from CI Reposi
 
 ## Input Parameters
 
-- **Context Folder Path** - Folder that contains `cd-repository-context.json` produced by `cd-repository-discover`.
+- **Context Folder Path** - Folder that contains `cd-repository-context.json` produced by `cd-repository-discovery`.
 - **Change Selectors** - One or more PR numbers and/or one git commit range (for example `abc123..def456`).
 
 ## Prerequisite
@@ -22,7 +22,7 @@ Read `cd-repository-context.json` from the provided folder and validate:
 - `cdRepositoryConfigPath`
 - `tooling.preferredChangeSource`
 
-If the context file is missing or invalid, stop and ask the user to run `cd-repository-discover` (or fix the file).
+If the context file is missing or invalid, stop and ask the user to run `cd-repository-discovery` (or fix the file).
 
 ## Workflow
 

--- a/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
@@ -92,6 +92,8 @@ Common CI paths to object types:
 
 **Channel-scoped content (pages, emails, headless items):** These are stored under `<ChannelName>/` rather than `@global/`. For example, `DancingGoat/cms.contentitem/` contains pages for the DancingGoat website channel. When these paths appear in CI changes, use `IncludedContentItemsOfType` / `ContentItemFilters` (v2) rather than `ObjectFilters`. See [CI/CD object type reference](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/reference-ci-cd-object-types#content-management) for details.
 
+**Resolving content item code names from channel-scoped diffs:** When a diff shows a change under `<ChannelName>/contentitemdata.<type>/<folder>/`, the folder name encodes the item as `<itemcodename>-<guid_prefix>` but is not directly usable as a `ContentItemFilters` code name. Always resolve the canonical code name by reading the corresponding `<ChannelName>/cms.contentitem/<itemcodename-guid>.xml` file and extracting the `<ContentItemName>` element. This is the value to use in `<IncludedContentItemNames>`.
+
 **Forms require two object types:** Both `@global/cms.form/` and `@global/cms.formclass/` must be included together. The `cms.formclass` files use a `bizform.` code name prefix (e.g., `bizform.userfeedback.xml`). Include both in `IncludedObjectTypes`:
 
   ```xml
@@ -102,6 +104,11 @@ Common CI paths to object types:
   ```
 
 **`@global/cms.class` ambiguity:** This folder covers both module class definitions and reusable field schema definitions. Inspect the file code names to determine which is present before scoping `ObjectFilters`.
+
+**`@global/cms.contentitemcommondata/` vs `@global/cms.class/cms.contentitemcommondata.xml` — do not confuse these two paths:**
+
+- `@global/cms.contentitemcommondata/<itemcodename>/` — these are **child data files** for individual content items (language variants, draft state, etc.). They are covered automatically when the parent content type is included via `IncludedContentItemsOfType`. Do **not** add `cms.contentitemcommondata` to `ObjectFilters`; the v2 format disallows it and will throw an exception.
+- `@global/cms.class/cms.contentitemcommondata.xml` — this single file is the **reusable field schema definition** and must be explicitly included via `cms.class` in `ObjectFilters` when changed.
 
 **Reusable field schemas** -> Object type `cms.class`. Reusable field schema definitions are tracked via the `CMS.ContentItemCommonData` code name (file path `App_Data\CIRepository\@global\cms.class\cms.contentitemcommondata.xml`). To include them, add both an `IncludedObjectTypes` entry and an `ObjectFilters` entry:
 
@@ -127,11 +134,38 @@ Common CI paths to object types:
 - Add content-item-specific filters only when content item deployment is intentionally requested.
 - Keep code name filters minimal and precise.
 
+## Formatting Guidelines
+
+Write code names one per line for readability. Within a single `<IncludedCodeNames>` element, list each code name on its own indented line with a semicolon separator (no trailing semicolon on the last entry):
+
+```xml
+<ObjectFilters>
+  <IncludedCodeNames ObjectType="cms.contenttype">
+    DancingGoat.Cafe;
+    DancingGoat.FAQItem;
+    DancingGoat.BuilderEmail
+  </IncludedCodeNames>
+  <IncludedCodeNames ObjectType="cms.class">
+    CMS.ContentItemCommonData
+  </IncludedCodeNames>
+</ObjectFilters>
+```
+
+For `ContentItemFilters`, use a separate `<IncludedContentItemNames>` element per item (not semicolons), one per line:
+
+```xml
+<ContentItemFilters>
+  <IncludedContentItemNames>BostonCoffeePlace-034jwdxo</IncludedContentItemNames>
+  <IncludedContentItemNames>CafePhoto-nu2tjd9a</IncludedContentItemNames>
+</ContentItemFilters>
+```
+
 ## Quality Checks
 
 - XML is well-formed.
 - No repeated `IncludedCodeNames` entries for the same object type.
 - Code names match actual CI object code names from XML files.
+- Code names listed one per line within elements (see Formatting Guidelines above).
 - Update-only groups are excluded (unless user opted in).
 - Final config diff is concise and justified.
 

--- a/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
@@ -94,6 +94,8 @@ Common CI paths to object types:
 
 **Resolving content item code names from channel-scoped diffs:** When a diff shows a change under `<ChannelName>/contentitemdata.<type>/<folder>/`, the folder name encodes the item as `<itemcodename>-<guid_prefix>` but is not directly usable as a `ContentItemFilters` code name. Always resolve the canonical code name by reading the corresponding `<ChannelName>/cms.contentitem/<itemcodename-guid>.xml` file and extracting the `<ContentItemName>` element. This is the value to use in `<IncludedContentItemNames>`.
 
+**Content type not changed but new items of that type were added:** When a CI diff adds new content item files under `@global/contentitemdata.<type>/` or `@global/cms.contentitem/` for a type whose `@global/cms.contenttype/<type>.xml` was **not** changed in any of the included commits, that content type must still be included in **both** `IncludedContentItemsOfType` and `ObjectFilters/IncludedCodeNames ObjectType="cms.contenttype"`. The type definition is unchanged but the type must be present in both places for `kxp-cd-store` to include the new items in the deployment package.
+
 **Forms require two object types:** Both `@global/cms.form/` and `@global/cms.formclass/` must be included together. The `cms.formclass` files use a `bizform.` code name prefix (e.g., `bizform.userfeedback.xml`). Include both in `IncludedObjectTypes`:
 
   ```xml
@@ -133,6 +135,7 @@ Common CI paths to object types:
 - Prefer explicit object types over broad `IncludeAll` patterns.
 - Add content-item-specific filters only when content item deployment is intentionally requested.
 - Keep code name filters minimal and precise.
+- **When `IncludedObjectTypes` contains `cms.contenttype` and `ObjectFilters` has an `IncludedCodeNames ObjectType="cms.contenttype"` entry, every content type listed in `IncludedContentItemsOfType` must also appear in that `ObjectFilters` code name list** — regardless of whether the type definition itself was changed in the included commits. If a type is missing from `ObjectFilters`, `kxp-cd-store` will silently suppress all content items of that type from the deployment package.
 
 ## Formatting Guidelines
 
@@ -168,6 +171,7 @@ For `ContentItemFilters`, use a separate `<IncludedContentItemNames>` element pe
 - Code names listed one per line within elements (see Formatting Guidelines above).
 - Update-only groups are excluded (unless user opted in).
 - Final config diff is concise and justified.
+- **Every `<ContentType>` listed in `IncludedContentItemsOfType` also appears in `ObjectFilters/IncludedCodeNames ObjectType="cms.contenttype"`** (when that filter element is present). Any content type absent from `ObjectFilters` will have its content items silently excluded from the deployment package by `kxp-cd-store`.
 
 ## Output Format
 

--- a/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
@@ -12,7 +12,7 @@ You are tasked with creating a scoped CD Repository configuration from CI Reposi
 - **Context Folder Path** - Folder that contains `cd-repository-context.json` produced by `cd-repository-discovery`.
 - **Change Selectors** - Provide **either** PR number(s) **or** a git commit range (not both):
   - **PR mode:** One or more PR numbers (e.g., `PR 312` or `PR 310, PR 311, PR 312`)
-  - **Commit mode:** One git commit range (e.g., `abc123..def456`)
+  - **Commit mode:** One git commit range (e.g., `abc123..def456`) which is inclusive
 
 Choose PR mode when deploying specific, discrete changes; choose commit mode when deploying all changes between two commits.
 
@@ -38,14 +38,20 @@ If the context file is missing or invalid, stop and ask the user to run `cd-repo
 2. Resolve change source strategy:
    - Prefer `gh` when context says `gh` and `gh` is available.
    - Otherwise use local git commands.
-3. Collect changed files for each selector:
-   - PR mode: collect file list from each PR.
-   - Commit range mode: run `git diff --name-only` from `repositoryRoot`.
-4. Keep only files under `ciRepositoryPath`.
-5. Classify CI changes into:
+3. **Collect and classify CI changes for each selector:**
+   - **PR mode:** Collect file list and changes for each PR separately.
+   - **Commit range mode:** 
+     - List all commits in the range using `git log <range> --pretty=format:"%H %s"`.
+     - For each commit in the range (oldest to newest):
+       - Run `git show <commit-hash> --name-status -- <ciRepositoryPath>` to get CI files changed in that commit.
+       - Extract commit subject/message to classify the commit intent.
+       - Classify the commit as **Business/feature** or **Xperience update-only** (see Change Classification Guidance below).
+       - Track CI changes per commit separately.
+4. Keep only files under `ciRepositoryPath` that belong to non-excluded commits.
+5. Aggregate CI changes across all non-excluded commits into:
    - **Business/feature changes** (include in deployment filtering)
    - **Xperience update-only changes** (exclude by default)
-6. Exclude update-only changes unless user explicitly requests inclusion.
+6. Exclude entire commits marked as `Xperience update-only` unless user explicitly requests inclusion.
 7. Map remaining CI paths to object types and code names.
 8. Update `cdRepositoryConfigPath`:
    - Build minimal `IncludedObjectTypes` allowlist (main object types only).
@@ -133,10 +139,13 @@ Common CI paths to object types:
 
 Finish with a concise deployment summary:
 
-- Reviewed source selectors (PRs / commit range)
+- **Source selectors analyzed:**
+  - For commit ranges: list all commits in the range with their subjects and classification (Business/Feature vs. Xperience update-only)
+  - For PRs: list all PR numbers analyzed
+- **Commits included in deployment scope** (with hashes and subjects)
+- **Commits excluded as Xperience update-only** (with hashes, subjects, and reason for exclusion)
 - Selected object types for deployment
 - Selected code names by object type
-- Explicitly excluded update-only groups and why
 - Determined RestoreMode and reasoning (Create vs. CreateUpdate based on git history)
 - Exact impact on `repository.config`
 - Validation result for deployment package export (if executed)

--- a/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
@@ -97,7 +97,7 @@ Common CI paths to object types:
 
 **`@global/cms.class` ambiguity:** This folder covers both module class definitions and reusable field schema definitions. Inspect the file code names to determine which is present before scoping `ObjectFilters`.
 
-**Reusable field schemas** -> Object type `cms.class`. Reusable field schema definitions are tracked via the `CMS.ContentItemCommonData` code name. To include them, add both an `IncludedObjectTypes` entry and an `ObjectFilters` entry:
+**Reusable field schemas** -> Object type `cms.class`. Reusable field schema definitions are tracked via the `CMS.ContentItemCommonData` code name (file path `App_Data\CIRepository\@global\cms.class\cms.contentitemcommondata.xml`). To include them, add both an `IncludedObjectTypes` entry and an `ObjectFilters` entry:
 
   ```xml
   <IncludedObjectTypes>

--- a/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
@@ -143,4 +143,4 @@ Finish with a concise deployment summary:
 
 ## Leveraging Kentico Documentation
 
-This skill has access to the Kentico Docs MCP server. If you need deeper information on any topic (content item filtering, CD Repository configuration, object types, etc.), reference the [CI/CD documentation](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/) to provide more accurate and detailed guidance.
+This skill has access to the Kentico Docs MCP server. If you need deeper information on any topic (content item filtering, CD Repository configuration, object types, etc.) use the MCP server to search for "Repository configuration templates" or "Reference - CI/CD object types" for specific syntax and configuration examples.

--- a/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-configure/SKILL.md
@@ -21,14 +21,18 @@ Read `cd-repository-context.json` from the provided folder and validate:
 - `ciRepositoryPath`
 - `cdRepositoryConfigPath`
 - `tooling.preferredChangeSource`
+- `discovery.repositoryConfigVersion` must be `"2"`
 
 If the context file is missing or invalid, stop and ask the user to run `cd-repository-discovery` (or fix the file).
+
+**If `discovery.repositoryConfigVersion` is `"1"` or missing:** Stop and inform the user:
+> "The repository.config file uses the legacy v1 syntax. The `cd-repository-configure` skill requires v2 syntax. Please run the `cd-repository-upgrade` skill to migrate your configuration to v2, then run `cd-repository-discovery` again to generate an updated context file. See [Migrate CI/CD repository.config to v2](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/configure-ci-cd-repositories/config-v2-migration) for details."
 
 ## Workflow
 
 1. Load discovery context and confirm paths still exist.
 2. Resolve change source strategy:
-   - Prefer `gh` when context says `gh-pr` and `gh` is available.
+   - Prefer `gh` when context says `gh` and `gh` is available.
    - Otherwise use local git commands.
 3. Collect changed files for each selector:
    - PR mode: collect file list from each PR.

--- a/plugins/configure-cd-repository/skills/cd-repository-discovery/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-discovery/SKILL.md
@@ -28,12 +28,13 @@ Write a JSON file with this shape (add additional helpful fields when available)
   "tooling": {
     "ghAvailable": true,
     "gitAvailable": true,
-    "preferredChangeSource": "gh|local git"
+    "preferredChangeSource": "gh|local-git"
   },
   "discovery": {
     "appPathSource": "user|discovered",
     "ciPathSource": "user|default|discovered",
     "cdConfigSource": "user|default|discovered",
+    "repositoryConfigVersion": "2",
     "notes": [
       "optional notes about assumptions or fallbacks"
     ]
@@ -47,7 +48,7 @@ Write a JSON file with this shape (add additional helpful fields when available)
    - Xperience app path
    - CI Repository path
    - CD repository.config path
-   - Preferred change source (`gh` or `local git`)
+   - Preferred change source (`gh` or `local-git`)
 
 2. Discover missing values automatically:
    - Search for `App_Data/CDRepository/repository.config`.
@@ -60,16 +61,21 @@ Write a JSON file with this shape (add additional helpful fields when available)
    - `ciRepositoryPath`
    - `cdRepositoryConfigPath`
 
-4. Detect tool availability:
+4. Detect repository.config syntax version:
+   - Open the `repository.config` file and check the root `<RepositoryConfiguration Version="X">` attribute.
+   - Record the version ("1" or "2") in `discovery.repositoryConfigVersion`.
+   - If Version attribute is missing, assume v1 and record accordingly.
+
+5. Detect tool availability:
    - Check if `gh` CLI is available.
    - Check if local `git` is available.
    - Set `preferredChangeSource`:
-     - Use `gh-pr` when `gh` is available and user did not force local git.
+     - Use `gh` when `gh` is available and user did not force local git.
      - Otherwise use `local-git`.
 
-5. Ensure the context folder exists, then write `cd-repository-context.json`.
+6. Ensure the context folder exists, then write `cd-repository-context.json`.
 
-6. Print a concise summary of what was discovered and where the context file was written.
+7. Print a concise summary of what was discovered and where the context file was written.
 
 ## Rules
 
@@ -78,6 +84,7 @@ Write a JSON file with this shape (add additional helpful fields when available)
 - Keep paths absolute in the context file.
 - Preserve user-provided values when valid; only fall back to discovery/defaults when needed.
 - If both `gh` and `git` are unavailable, still write context with clear error notes and ask user to resolve tooling.
+- If `repository.config` uses v1 syntax, record this in the context file and include a warning in the output summary.
 
 ## Output Format
 
@@ -87,5 +94,8 @@ Conclude with:
 - App path
 - CI repository path
 - CD repository.config path
+- Repository.config syntax version
 - Tooling status (`gh`, `git`, chosen source)
 - Any assumptions/fallbacks recorded
+- **If v1 syntax detected:** Include this warning in the summary:
+  > ⚠️ **Note:** The repository.config file uses the legacy v1 syntax. Before running `cd-repository-configure`, you must upgrade to v2 syntax using the `cd-repository-upgrade` skill. See [Migrate CI/CD repository.config to v2](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/configure-ci-cd-repositories/config-v2-migration) for details.

--- a/plugins/configure-cd-repository/skills/cd-repository-discovery/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-discovery/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: cd-repository-discover
+description: "Discovers Xperience by Kentico deployment context (app path, CI/CD repository paths, and available git tooling) and saves it to a reusable context file for follow-up CD repository configuration."
+argument-hint: "Path to a folder where discovery context should be written"
+---
+
+You are tasked with discovering repository and environment context required to build CD Repository filters.
+
+## Input Parameters
+
+- **Context Folder Path** - User-provided folder where you must write the discovery context file.
+
+## Primary Goal
+
+Create a machine-readable context file named `cd-repository-context.json` in the provided folder.
+
+## Context File Contract
+
+Write a JSON file with this shape (add additional helpful fields when available):
+
+```json
+{
+  "generatedAtUtc": "ISO-8601 UTC timestamp",
+  "repositoryRoot": "absolute path to git repository root",
+  "appPath": "absolute path to Xperience by Kentico app",
+  "ciRepositoryPath": "{appPath}/App_Data/CIRepository",
+  "cdRepositoryConfigPath": "{appPath}/App_Data/CDRepository/repository.config",
+  "tooling": {
+    "ghAvailable": true,
+    "gitAvailable": true,
+    "preferredChangeSource": "gh-pr|local-git"
+  },
+  "discovery": {
+    "appPathSource": "user|discovered",
+    "ciPathSource": "user|default|discovered",
+    "cdConfigSource": "user|default|discovered",
+    "notes": [
+      "optional notes about assumptions or fallbacks"
+    ]
+  }
+}
+```
+
+## Steps To Follow
+
+1. Ask the user for optional known values:
+   - Xperience app path
+   - CI Repository path
+   - CD repository.config path
+   - Preferred change source (`gh` or `local git`)
+
+2. Discover missing values automatically:
+   - Search for `App_Data/CDRepository/repository.config`.
+   - Search for `App_Data/CIRepository`.
+   - Infer `appPath` as the parent folder of `App_Data`.
+   - If multiple candidates exist, pick the best match by proximity/consistency and note alternatives in `discovery.notes`.
+
+3. Validate all required paths exist:
+   - `appPath`
+   - `ciRepositoryPath`
+   - `cdRepositoryConfigPath`
+
+4. Detect tool availability:
+   - Check if `gh` CLI is available.
+   - Check if local `git` is available.
+   - Set `preferredChangeSource`:
+     - Use `gh-pr` when `gh` is available and user did not force local git.
+     - Otherwise use `local-git`.
+
+5. Ensure the context folder exists, then write `cd-repository-context.json`.
+
+6. Print a concise summary of what was discovered and where the context file was written.
+
+## Rules
+
+- Do not edit `repository.config` in this skill.
+- Do not guess silently. If a critical value cannot be determined, ask a focused follow-up question.
+- Keep paths absolute in the context file.
+- Preserve user-provided values when valid; only fall back to discovery/defaults when needed.
+- If both `gh` and `git` are unavailable, still write context with clear error notes and ask user to resolve tooling.
+
+## Output Format
+
+Conclude with:
+
+- Context file path
+- App path
+- CI repository path
+- CD repository.config path
+- Tooling status (`gh`, `git`, chosen source)
+- Any assumptions/fallbacks recorded

--- a/plugins/configure-cd-repository/skills/cd-repository-discovery/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-discovery/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: cd-repository-discover
+name: cd-repository-discovery
 description: "Discovers Xperience by Kentico deployment context (app path, CI/CD repository paths, and available git tooling) and saves it to a reusable context file for follow-up CD repository configuration."
 argument-hint: "Path to a folder where discovery context should be written"
 ---
@@ -28,7 +28,7 @@ Write a JSON file with this shape (add additional helpful fields when available)
   "tooling": {
     "ghAvailable": true,
     "gitAvailable": true,
-    "preferredChangeSource": "gh-pr|local-git"
+    "preferredChangeSource": "gh|local git"
   },
   "discovery": {
     "appPathSource": "user|discovered",

--- a/plugins/configure-cd-repository/skills/cd-repository-upgrade/SKILL.md
+++ b/plugins/configure-cd-repository/skills/cd-repository-upgrade/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: cd-repository-upgrade
+description: "Migrates a CD Repository configuration file from v1 syntax to v2, enabling advanced content item filtering and improving CD restore performance. Automatically locates the config file from the discovery context if not provided."
+argument-hint: "(Optional) Path to repository.config file, or path to folder containing cd-repository-context.json"
+---
+
+You are tasked with migrating a CD Repository `repository.config` file from v1 to v2 syntax.
+
+## Input Parameters
+
+- **Repository Config Path** - *(Optional)* Absolute or relative path to the `repository.config` file to migrate.
+
+If no path is provided, the skill will attempt to locate the context file (`cd-repository-context.json`) in the current directory or its parent folders. If found, it will extract the `cdRepositoryConfigPath` from the context file.
+
+## Discovery Logic
+
+If no repository config path is provided as an argument:
+
+1. Search for `cd-repository-context.json` in the current directory and parent directories (up to 3 levels).
+2. If found, read the file and extract `cdRepositoryConfigPath`.
+3. If not found, ask the user to provide either:
+   - The path to the `repository.config` file directly, or
+   - The path to the folder containing `cd-repository-context.json`
+
+## Primary Goal
+
+Transform the config file to v2 syntax in-place, with a backup of the original, enabling advanced content item filtering and improved CD restore performance.
+
+## Transformation Steps
+
+### 1. Locate and Validate Input
+
+**If repository config path was provided as argument:**
+- Validate the file exists and is valid XML.
+
+**If repository config path was NOT provided:**
+- Use the discovery logic from the "Discovery Logic" section above to locate `cd-repository-context.json`.
+- Extract `cdRepositoryConfigPath` from the context file.
+- If context file cannot be found, ask the user to provide the config path or context folder path.
+
+**For all cases, after locating the file:**
+- Check that the file exists and is valid XML.
+- Detect the current version:
+  - If `<RepositoryConfiguration>` lacks a `Version` attribute or has `Version="1"`, it's v1.
+  - If `Version="2"`, inform the user it's already v2 and stop.
+  - If any other version, ask the user to verify.
+
+### 2. Create Backup
+
+Create a backup file named `repository.config.v1.backup` in the same directory.
+
+### 3. Migrate RepositoryConfiguration Element
+
+Update the root element to include `Version="2"`:
+
+```xml
+<!-- Before -->
+<RepositoryConfiguration
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+<!-- After -->
+<RepositoryConfiguration 
+  Version="2"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+```
+
+### 4. Ensure IncludedObjectTypes Exists and Is Explicit
+
+**Behavior change:** In v1, `IncludedObjectTypes` is optional (defaults to all objects). In v2, it must be explicit.
+
+- If `<IncludedObjectTypes>` is missing or empty, add/replace with `<IncludeAll />`.
+- If `<IncludedObjectTypes>` already contains specific object types, keep them as-is.
+- Preserve any `<ExcludedObjectTypes>` section unchanged.
+
+### 5. Remove Content Item Object Types from ObjectFilters
+
+The following object types can **no longer** appear in `<ObjectFilters>` with `<IncludedCodeNames>` or `<ExcludedCodeNames>`:
+
+- `cms.contentitem`
+- `cms.contentitemcommondata`
+- `cms.contentitemlanguagemetadata`
+- `cms.contentitemreference`
+- `cms.webpageitem`
+- `cms.webpageformerurlpath`
+- `cms.webpageurlpath`
+- `emaillibrary.emailconfiguration`
+- `emaillibrary.sendconfiguration`
+- `cms.headlessitem`
+
+**Migration approach:**
+
+- Search `ObjectFilters` for any filters applied to these object types.
+- **For content item code name filters (e.g., `<IncludedCodeNames ObjectType="cms.contentitem">` or `<ExcludedCodeNames ObjectType="cms.contentitem">`):**
+  - Extract the code name patterns (both included and excluded).
+  - **Do NOT remove them yet** – they will be migrated to the new `ContentItemFilters` element in the next step.
+  - Remove only the ObjectFilter entries for these object types from `ObjectFilters`.
+  - Make a note of the extracted patterns for step 6.
+- **For other object type filters:** Keep them unchanged in `ObjectFilters`.
+
+See [Configure content item filters](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/configure-ci-cd-repositories#configure-content-item-filters) in the Kentico documentation for details on the new approach.
+
+### 6. Migrate Content Item Code Name Filters to ContentItemFilters
+
+If the v1 config had any `<IncludedCodeNames ObjectType="cms.contentitem">` or `<ExcludedCodeNames ObjectType="cms.contentitem">` entries, create a new `<ContentItemFilters>` section to preserve this filtering.
+
+**Example migration:**
+
+```xml
+<!-- v1 config -->
+<ObjectFilters>
+  <IncludedCodeNames ObjectType="cms.contentitem">article.spring-launch;coffee.espresso;offer.summer</IncludedCodeNames>
+  <ExcludedCodeNames ObjectType="cms.contentitem">article.draft%;offer.internal%</ExcludedCodeNames>
+</ObjectFilters>
+
+<!-- Migrates to v2 config -->
+<ContentItemFilters>
+  <IncludedContentItemNames>
+    article.spring-launch;coffee.espresso;offer.summer
+  </IncludedContentItemNames>
+  <ExcludedContentItemNames>
+    article.draft%;offer.internal%
+  </ExcludedContentItemNames>
+</ContentItemFilters>
+```
+
+**Placement:** Add `<ContentItemFilters>` **after** `<IncludedContentItemsOfType>` and before `<ObjectFilters>`.
+
+**If no content item code name filters existed:** Omit this section. Users can add it later if needed.
+
+See [Configure content item filters](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/configure-ci-cd-repositories#configure-content-item-filters) for full details.
+
+### 7. Add Content Items Section (If Not Present)
+
+If no `<IncludedContentItemsOfType>` exists, add a new section **after** `IncludedObjectTypes` and **before** `ContentItemFilters` or `ExcludedObjectTypes` (if present):
+
+```xml
+<IncludedContentItemsOfType>
+  <!-- Explicitly list content types or use <IncludeAll /> -->
+  <IncludeAll />
+</IncludedContentItemsOfType>
+```
+
+**Note:** Use `<IncludeAll />` as the safe default migration choice. The user can refine this post-migration by specifying individual content types.
+
+If `<IncludedContentItemsOfType>` already exists, preserve it as-is.
+
+### 9. Update Discovery Context File (If Applicable)
+
+If the config path was discovered from a `cd-repository-context.json` file (rather than provided as an argument):
+
+- Read the context file again to ensure you have the latest version.
+- Update the `discovery.repositoryConfigVersion` field from `"1"` to `"2"`.
+- Write the updated context file back to disk.
+- Include a note in the output that the context file was updated.
+
+If the config path was provided explicitly as an argument, skip this step.
+
+### 10. Validate XML
+
+Parse the resulting XML to ensure it is well-formed. If validation fails, report the error and do not overwrite the original file.
+
+### 11. Write Migrated File
+
+- Overwrite the original `repository.config` with the migrated v2 syntax.
+- Preserve formatting and indentation where possible.
+
+## Output Format
+
+Conclude with a clear summary:
+
+```
+✅ Migration Complete
+
+Config File: [absolute path to repository.config]
+Backup: [absolute path to backup file]
+[If discovered from context: Located via cd-repository-context.json]
+[If context file was updated: Updated discovery context at [path]]
+
+Changes Made:
+- Added Version="2" to RepositoryConfiguration element
+- [List specific changes made]
+
+Content Item Configuration:
+- [Describe IncludedContentItemsOfType changes]
+- [If content item code name filters were found and migrated to ContentItemFilters, note them explicitly]
+- [Note if user needs to manually review or refine IncludedContentItemsOfType with specific types instead of IncludeAll]
+
+Next Steps:
+1. Review the migrated repository.config, especially:
+   - IncludedContentItemsOfType configuration (consider replacing `<IncludeAll />` with specific content types for better performance)
+   - ContentItemFilters if present (verify the migrated code name patterns are correct)
+   - ObjectFilters to ensure non-content-item filters were preserved correctly
+2. Test the migrated config by running a CD store operation:
+   dotnet run --no-build -- --kxp-cd-store --repository-path "C:\path\to\CDRepository" --config-path "C:\path\to\repository.config"
+   See [Store objects to a CD Repository](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/continuous-deployment#store-objects-to-a-cd-repository) for details.
+3. Use 'cd-repository-configure' to build scoped deployment filters from PR/commit changes
+
+References:
+- [Migrate CI/CD repository.config to v2](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/configure-ci-cd-repositories/config-v2-migration)
+- [Configure content item filters](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/configure-ci-cd-repositories#configure-content-item-filters)
+- [Store objects to a CD Repository](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/continuous-deployment#store-objects-to-a-cd-repository)
+```
+
+## Rules
+
+- **Discover from context when available.** If no config path is provided, automatically search for and use `cd-repository-context.json` to locate the config file.
+- **Update context file if used.** If the config was discovered from a context file, update `discovery.repositoryConfigVersion` from `"1"` to `"2"` in that file. This eliminates the need for the user to run discovery again.
+- **Backup first.** Always create a backup before modifying the original file.
+- **Preserve non-content-item filters.** Do not remove or modify `ObjectFilters` for non-content-item object types.
+- **Migrate content item code name filters.** If the v1 config has `<IncludedCodeNames ObjectType="cms.contentitem">` or `<ExcludedCodeNames ObjectType="cms.contentitem">`, migrate these to the new `<ContentItemFilters>` element with `<IncludedContentItemNames>` and `<ExcludedContentItemNames>`. See [Configure content item filters](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/configure-ci-cd-repositories#configure-content-item-filters) for details.
+- **Be explicit about content item filtering.** In the summary, explain what happened with content item filters and guide the user on fine-tuning `IncludedContentItemsOfType` (e.g., replacing `<IncludeAll />` with specific content types for better performance).
+- **Use correct CD commands.** When referencing testing steps, use `--kxp-cd-store` for CD Repository operations (not `--kxp-ci-store`, which is for CI Repository).
+- **Validate before writing.** Ensure the migrated XML is well-formed before overwriting the original.
+- **Idempotent.** If the file is already v2, do not process it again.
+- **Preserve existing IncludedContentItemsOfType.** If the user already has this section configured, do not replace it.
+
+## Decision Tree
+
+**Is the file already v2?**
+→ Stop. Inform the user it's already v2 and no migration is needed.
+
+**Does IncludedObjectTypes exist and is not empty?**
+→ Keep as-is.
+
+**Does IncludedObjectTypes not exist or is empty?**
+→ Replace with `<IncludeAll />`.
+
+**Does ObjectFilters contain cms.contentitem or related types (cms.contentitem, cms.contentitemcommondata, etc.)?**
+→ Extract code name patterns from IncludedCodeNames/ExcludedCodeNames for cms.contentitem.
+→ If patterns exist, create a new `<ContentItemFilters>` section with `<IncludedContentItemNames>` and `<ExcludedContentItemNames>` using the extracted patterns.
+→ Remove the cms.contentitem-related filter entries from `ObjectFilters`.
+→ Note in the summary which content item code name patterns were migrated.
+
+**Does IncludedContentItemsOfType not exist?**
+→ Add `<IncludedContentItemsOfType><IncludeAll /></IncludedContentItemsOfType>` as safe default.
+
+**Does the migrated XML validate?**
+→ If yes, write the file. If no, report the error and do not overwrite.


### PR DESCRIPTION
# Motivation

Add a new plugin to help teams configure their CD Repository `repository.config` when prepping an Xperience by Kentico deployment of new object type, content type, and content changes.

Plugin includes 2 skills:

| Skill                     | Description                                                                                          |
| ------------------------- | ---------------------------------------------------------------------------------------------------- |
| `cd-repository-discovery`  | Locates the Xperience app, CI/CD repository paths, and git tooling; saves context to a reusable file |
| `cd-repository-configure` | Reads the context file and PR/commit changes, then writes a scoped `repository.config`               |
| `cd-repository-upgrade` | Migrates a CD Repository configuration file from v1 syntax to v2               |

The discover skill will be run to set up the environment and the configure skill will be run for each schema change deployment.

This plugin was adapted from a skill I've been using successfully [in the Kentico Community Portal](https://github.com/Kentico/community-portal/blob/v31.3.2.5/.agents/skills/configure-cdrepository/SKILL.md).

## Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [X] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

If manual testing is required, what are the steps?
