### PR TITLE
TRAIN-3557 :: Add recommendations to structure/name folders as skills expect

### DIFF
--- a/plugins/kx13-content-audit/README.md
+++ b/plugins/kx13-content-audit/README.md
@@ -50,7 +50,7 @@ copilot plugin install kx13-content-audit@xperience-by-kentico-kenticopilot
 
 The plugin install does not include the CLI source. Set it up once per workspace:
 
-1. Clone this repository so the plugin folder is available locally.
+1. Clone this repository so the plugin folder is available locally. (We recommend ensuring the *kx13-content-audit* folder sits directly in the root of your workspace.)
 2. Configure the connection string in the CLI project's `appsettings.json` (`src/KX13.ContentAuditor.CLI/appsettings.json` inside the plugin folder):
 
    ```json

--- a/plugins/kx13-content-migration/README.md
+++ b/plugins/kx13-content-migration/README.md
@@ -84,6 +84,9 @@ Place the KX13 source, XbyK target, Migration Tool, and the content-audit output
 └── MigrationProtocol/               # Created by migrate-run; consumed by migrate-eval
 ```
 
+> [!TIP]
+> While many agents can adapt to different folder names and structures, following the diagram above will align your workspace with the skills and reduce the risk of issues.
+
 Ensure the KX13 database is reachable from the machine running the Migration Tool, and that the XbyK database is initialized but otherwise empty (or carrying prior migration data to upsert).
 
 ### Configure MCP servers


### PR DESCRIPTION


# Motivation

Recommendations about folder names and structure are slightly vague in the kx13 content audit and content migration README files, despite the skills expecting specific names/locations.

While many agents can easily search/adapt to different names and locations, it's still worth recommending the path of least resistance.
