### PR TITLE
KX-24472 - Update Xperience skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ The complete toolkit for upgrading a Kentico Xperience 13 project to Xperience b
 
 > **Location:** [plugins/kentico-project-lifecycle/](./plugins/kentico-project-lifecycle/)
 
-Skills for managing the lifecycle of an Xperience by Kentico solution. The first capability builds scoped [Continuous Deployment Repository](https://docs.kentico.com/x/continuous_deployment) filters from CI Repository changes: the AI discovers your project layout and tooling, then inspects changed CI Repository files from specified PRs or commit ranges and writes a minimal `IncludedObjectTypes` / `ObjectFilters` allowlist — automatically excluding noise from Xperience version updates. Full instructions are available in the [README](./plugins/kentico-project-lifecycle/README.md).
+Skills for managing the lifecycle of an Xperience by Kentico solution. The plugin updates projects to newer Xperience versions by following the official release notes and update documentation, and builds scoped [Continuous Deployment Repository](https://docs.kentico.com/x/continuous_deployment) filters from CI Repository changes: the AI discovers your project layout and tooling, then inspects changed CI Repository files from specified PRs or commit ranges and writes a minimal `IncludedObjectTypes` / `ObjectFilters` allowlist — automatically excluding noise from Xperience version updates. Full instructions are available in the [README](./plugins/kentico-project-lifecycle/README.md).
 
 | Skill                     | Description                                                                                          |
 | ------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `update-xperience`        | Updates the project to a newer Xperience version, driven by the release notes and official docs      |
 | `cd-repository-discovery` | Locates the Xperience app, CI/CD repository paths, and git tooling; saves context to a reusable file |
 | `cd-repository-configure` | Reads the context file and PR/commit changes, then writes a scoped `repository.config`               |
 | `cd-repository-upgrade`   | Migrates a `repository.config` from v1 to v2 syntax                                                  |

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ The complete toolkit for upgrading a Kentico Xperience 13 project to Xperience b
 
 > **Location:** [plugins/kentico-project-lifecycle/](./plugins/kentico-project-lifecycle/)
 
-Skills for managing the lifecycle of an Xperience by Kentico solution. The plugin updates projects to newer Xperience versions by following the official release notes and update documentation, and builds scoped [Continuous Deployment Repository](https://docs.kentico.com/x/continuous_deployment) filters from CI Repository changes: the AI discovers your project layout and tooling, then inspects changed CI Repository files from specified PRs or commit ranges and writes a minimal `IncludedObjectTypes` / `ObjectFilters` allowlist — automatically excluding noise from Xperience version updates. Full instructions are available in the [README](./plugins/kentico-project-lifecycle/README.md).
+Skills for managing the lifecycle of an Xperience by Kentico solution. The plugin updates projects to newer Xperience versions, and builds scoped [Continuous Deployment Repository](https://docs.kentico.com/x/continuous_deployment) filters from CI Repository changes: the AI discovers your project layout and tooling, then inspects changed CI Repository files from specified PRs or commit ranges and writes a minimal `IncludedObjectTypes` / `ObjectFilters` allowlist — automatically excluding noise from Xperience version updates. Full instructions are available in the [README](./plugins/kentico-project-lifecycle/README.md).
 
 | Skill                     | Description                                                                                          |
 | ------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `update-xperience`        | Updates the project to a newer Xperience version, driven by the release notes and official docs      |
+| `update-xperience`        | Updates the project to a newer Xperience version                                                     |
 | `cd-repository-discovery` | Locates the Xperience app, CI/CD repository paths, and git tooling; saves context to a reusable file |
 | `cd-repository-configure` | Reads the context file and PR/commit changes, then writes a scoped `repository.config`               |
 | `cd-repository-upgrade`   | Migrates a `repository.config` from v1 to v2 syntax                                                  |

--- a/plugins/kentico-project-lifecycle/README.md
+++ b/plugins/kentico-project-lifecycle/README.md
@@ -1,10 +1,15 @@
 # Kentico project lifecycle
 
-Skills for managing the lifecycle of an Xperience by Kentico solution. The plugin currently focuses on configuring the [Continuous Deployment (CD) Repository](https://docs.kentico.com/x/continuous_deployment): the skills discover your project layout, inspect CI Repository changes from one or more pull requests or commit ranges, and produce a scoped `repository.config` that captures only your feature changes — while automatically excluding noise from Xperience version updates. More project-lifecycle capabilities are planned.
+Skills for managing the lifecycle of an Xperience by Kentico solution. The plugin currently covers two areas:
+
+- **Updating your Xperience project** — the `update-xperience` skill updates a project to a newer Xperience by Kentico version by following the official release notes and update documentation.
+- **Configuring the [Continuous Deployment (CD) Repository](https://docs.kentico.com/x/continuous_deployment)** — the `cd-repository-*` skills discover your project layout, inspect CI Repository changes from one or more pull requests or commit ranges, and produce a scoped `repository.config` that captures only your feature changes — while automatically excluding noise from Xperience version updates.
+
+More project-lifecycle capabilities are planned.
 
 ## Workflow
 
-These skills provide three-stage assistance for building CD Repository filters:
+The CD Repository skills provide three-stage assistance for building CD Repository filters:
 
 1. **Discovery stage** – Locates the Xperience app folder, CI and CD Repository paths, and available git tooling. Detects the `repository.config` syntax version. Saves everything to a reusable context file so you don't have to re-enter paths for every deployment.
 2. **Upgrade stage** (if needed) – If discovery detects a legacy v1 `repository.config`, migrates it to v2 syntax to enable advanced content item filtering and improved CD restore performance. Automatically updates the context file when complete.
@@ -12,9 +17,9 @@ These skills provide three-stage assistance for building CD Repository filters:
 
 ## Prerequisites
 
-- Xperience by Kentico project with CI/CD Repository enabled
+- Xperience by Kentico project
 - AI coding assistant installed (for example, GitHub Copilot or Claude Code)
-- `gh` CLI (recommended) or local `git` available in your terminal
+- For the CD Repository skills: CI/CD Repository enabled and `gh` CLI (recommended) or local `git` available in your terminal
 
 ## Install the plugin
 
@@ -46,13 +51,35 @@ copilot plugin install kentico-project-lifecycle@xperience-by-kentico-kenticopil
 
 ## Usage
 
-### 1. Run the discovery stage
+### Update your Xperience project
+
+The update skill identifies your current and target Xperience versions, reviews the release notes for every version in between (including the feature-specific update guides they link to), and follows the official update documentation.
+
+#### VS Code GitHub Copilot example
+
+```text
+/update-xperience
+```
+
+To update to a specific version instead of the latest:
+
+```text
+/update-xperience
+
+Target version: 30.9.2
+```
+
+### Configure the CD Repository
+
+The CD Repository skills run in the three stages described in the [Workflow](#workflow) section above.
+
+#### 1. Run the discovery stage
 
 The discovery skill finds your Xperience app path, CI and CD Repository locations, and detects whether `gh` or local `git` should be used to retrieve change information. It also detects the current `repository.config` syntax version. It writes this context to a `cd-repository-context.json` file in a folder you specify.
 
 You only need to run this once per project (or after your project structure changes).
 
-#### VS Code GitHub Copilot example
+##### VS Code GitHub Copilot example
 
 ```text
 /cd-repository-discovery
@@ -62,11 +89,11 @@ Save context to: C:/my-project/.cd-context
 
 The skill will ask for any values it cannot discover automatically (for example, the Xperience app path if multiple candidates exist in the workspace). It will also report the `repository.config` syntax version detected.
 
-### 2. Upgrade config syntax (if needed)
+#### 2. Upgrade config syntax (if needed)
 
 If discovery detected a legacy v1 `repository.config`, upgrade it to v2 first to enable advanced content item filtering and improve CD restore performance.
 
-#### VS Code GitHub Copilot example — with explicit config path
+##### VS Code GitHub Copilot example — with explicit config path
 
 ```text
 /cd-repository-upgrade
@@ -74,7 +101,7 @@ If discovery detected a legacy v1 `repository.config`, upgrade it to v2 first to
 Repository config path: C:/my-project/App_Data/CDRepository/repository.config
 ```
 
-#### VS Code GitHub Copilot example — auto-discover from context
+##### VS Code GitHub Copilot example — auto-discover from context
 
 If you've already run `cd-repository-discovery`, you can run the upgrade skill without arguments and it will automatically locate the config file from the context file:
 
@@ -84,11 +111,11 @@ If you've already run `cd-repository-discovery`, you can run the upgrade skill w
 
 The skill will create a backup (`repository.config.v1.backup`) and migrate the file to v2 syntax. If it discovered the config from a context file, it will automatically update the context to reflect v2 syntax. Proceed to step 3 (configure stage).
 
-### 3. Run the configure stage
+#### 3. Run the configure stage
 
 Provide the folder containing the context file written in step 1, along with the PR numbers or git commit range you want to deploy.
 
-#### VS Code GitHub Copilot example — single PR
+##### VS Code GitHub Copilot example — single PR
 
 ```text
 /cd-repository-configure
@@ -97,7 +124,7 @@ Context folder: C:/my-project/.cd-context
 Changes: PR 312
 ```
 
-#### VS Code GitHub Copilot example — multiple PRs
+##### VS Code GitHub Copilot example — multiple PRs
 
 ```text
 /cd-repository-configure
@@ -106,7 +133,7 @@ Context folder: C:/my-project/.cd-context
 Changes: PR 310, PR 311, PR 312
 ```
 
-#### VS Code GitHub Copilot example — commit range
+##### VS Code GitHub Copilot example — commit range
 
 The `..` range operator follows standard git syntax: the start commit is **exclusive** and the end commit is **inclusive**. Use the commit just before your first feature commit as the start of the range.
 
@@ -163,6 +190,16 @@ If `Export-DeploymentPackage.ps1` is present in the repository, the skill runs i
 - Keep the generated `cd-repository-context.json` local to your machine because it contains absolute, machine-specific paths. Optionally add the context folder to `.gitignore`. If you want to share the expected context structure with teammates, commit a template or example context file instead of the generated one.
 
 ## Skill reference
+
+### update-xperience
+
+Skill name: **update-xperience**
+
+Updates an Xperience by Kentico project to a newer version by following the official release notes and update documentation. Reviews the [Changelog](https://docs.kentico.com/changelog) for every version in the update path, follows the feature-specific update guides linked from the release notes, and performs the update per the [official update procedure](https://docs.kentico.com/documentation/developers-and-admins/installation/update-xperience-by-kentico-projects).
+
+**Argument hint:** Optional target version (defaults to the latest available).
+
+**Use when:** You want to update your Xperience project to a newer version, apply a hotfix, or move to a newer refresh.
 
 ### cd-repository-upgrade
 

--- a/plugins/kentico-project-lifecycle/README.md
+++ b/plugins/kentico-project-lifecycle/README.md
@@ -2,7 +2,7 @@
 
 Skills for managing the lifecycle of an Xperience by Kentico solution. The plugin currently covers two areas:
 
-- **Updating your Xperience project** — the `update-xperience` skill updates a project to a newer Xperience by Kentico version by following the official release notes and update documentation.
+- **Updating your Xperience project** — the `update-xperience` skill updates a project to a newer Xperience by Kentico version.
 - **Configuring the [Continuous Deployment (CD) Repository](https://docs.kentico.com/x/continuous_deployment)** — the `cd-repository-*` skills discover your project layout, inspect CI Repository changes from one or more pull requests or commit ranges, and produce a scoped `repository.config` that captures only your feature changes — while automatically excluding noise from Xperience version updates.
 
 More project-lifecycle capabilities are planned.
@@ -64,9 +64,7 @@ The update skill identifies your current and target Xperience versions, reviews 
 To update to a specific version instead of the latest:
 
 ```text
-/update-xperience
-
-Target version: 30.9.2
+/update-xperience 30.9.2
 ```
 
 ### Configure the CD Repository
@@ -195,7 +193,7 @@ If `Export-DeploymentPackage.ps1` is present in the repository, the skill runs i
 
 Skill name: **update-xperience**
 
-Updates an Xperience by Kentico project to a newer version by following the official release notes and update documentation. Reviews the [Changelog](https://docs.kentico.com/changelog) for every version in the update path, follows the feature-specific update guides linked from the release notes, and performs the update per the [official update procedure](https://docs.kentico.com/documentation/developers-and-admins/installation/update-xperience-by-kentico-projects).
+Updates an Xperience by Kentico project to a newer version. Reviews the [Changelog](https://docs.kentico.com/changelog) for every version in the update path, follows the feature-specific update guides linked from the release notes, and performs the update per the [official update procedure](https://docs.kentico.com/documentation/developers-and-admins/installation/update-xperience-by-kentico-projects).
 
 **Argument hint:** Optional target version (defaults to the latest available).
 

--- a/plugins/kentico-project-lifecycle/skills/update-xperience/SKILL.md
+++ b/plugins/kentico-project-lifecycle/skills/update-xperience/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "update-xperience"
-description: "Updates an Xperience by Kentico project to a newer version by following the official release notes and update documentation. Use when the user wants to update or upgrade their Xperience by Kentico project, apply a hotfix, or move to a newer refresh."
+description: "Updates an Xperience by Kentico project to a newer version. Use when the user wants to update or upgrade their Xperience by Kentico project, apply a hotfix, or move to a newer refresh."
 argument-hint: "[target-version]"
 compatibility: "Requires Kentico Docs MCP"
 ---
@@ -25,12 +25,18 @@ You are tasked with updating an Xperience by Kentico project to a newer version.
 - Read `references/update-docs.md` and fetch the relevant documentation pages.
 - Perform the update as documented — do not substitute your own procedure or external tools; everything needed (including CI handling) is built into the product's CLI.
 
-### 4. Resolve breaking changes
+### 4. Resolve breaking changes and obsolete API
 
 - Apply the code and configuration changes required by the release notes and their linked guides.
 - Build the solution and fix remaining errors caused by the update.
+- After the build succeeds, resolve obsolete-API warnings: migrate the affected code to the replacements described in the obsolete warning messages.
 
-### 5. Verify and report
+### 5. Update CI/CD repository configuration
+
+- If the project uses the `IncludedObjectTypes` element in a CI or CD `repository.config`, collect the **New object types for CI/CD** entries from the release notes of every version in the update path.
+- Add the new object types the project should include to the allowlist, per the official update documentation.
+
+### 6. Verify and report
 
 - Verify the result (build, tests if present).
 - Summarize what was updated and which release-note items required action.

--- a/plugins/kentico-project-lifecycle/skills/update-xperience/SKILL.md
+++ b/plugins/kentico-project-lifecycle/skills/update-xperience/SKILL.md
@@ -22,7 +22,7 @@ You are tasked with updating an Xperience by Kentico project to a newer version.
 
 ### 3. Follow the official update procedure
 
-- Read `references/update-docs.md` and fetch the relevant documentation pages via the Kentico Docs MCP.
+- Read `references/update-docs.md` and fetch the relevant documentation pages.
 - Perform the update as documented — do not substitute your own procedure or external tools; everything needed (including CI handling) is built into the product's CLI.
 
 ### 4. Resolve breaking changes

--- a/plugins/kentico-project-lifecycle/skills/update-xperience/SKILL.md
+++ b/plugins/kentico-project-lifecycle/skills/update-xperience/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: "update-xperience"
+description: "Updates an Xperience by Kentico project to a newer version by following the official release notes and update documentation. Use when the user wants to update or upgrade their Xperience by Kentico project, apply a hotfix, or move to a newer refresh."
+argument-hint: "[target-version]"
+compatibility: "Requires Kentico Docs MCP"
+---
+
+You are tasked with updating an Xperience by Kentico project to a newer version. The official release notes and update documentation are the source of truth — follow them, do not invent update steps.
+
+## Workflow
+
+### 1. Determine the versions
+
+- Identify the current version from the `Kentico.Xperience.*` NuGet package references in the project.
+- Identify the target version: use the version passed as an argument if provided, otherwise the latest available.
+
+### 2. Review the release notes
+
+- Read the release notes in the [Changelog](https://docs.kentico.com/changelog) for **every version between the current and target version**.
+- Note breaking changes, deprecations, new object types for CI/CD, and any manual steps.
+- **Follow the pages linked from the release notes** that guide through specific feature updates — they contain the instructions for adapting the project.
+
+### 3. Follow the official update procedure
+
+- Read `references/update-docs.md` and fetch the relevant documentation pages via the Kentico Docs MCP.
+- Perform the update as documented — do not substitute your own procedure or external tools; everything needed (including CI handling) is built into the product's CLI.
+
+### 4. Resolve breaking changes
+
+- Apply the code and configuration changes required by the release notes and their linked guides.
+- Build the solution and fix remaining errors caused by the update.
+
+### 5. Verify and report
+
+- Verify the result (build, tests if present).
+- Summarize what was updated and which release-note items required action.

--- a/plugins/kentico-project-lifecycle/skills/update-xperience/references/update-docs.md
+++ b/plugins/kentico-project-lifecycle/skills/update-xperience/references/update-docs.md
@@ -11,5 +11,3 @@ Fetch any link via the Kentico Docs MCP. Read only what the task needs.
 
 - **Update Xperience by Kentico projects**: https://docs.kentico.com/documentation/developers-and-admins/installation/update-xperience-by-kentico-projects
   - When to read: performing the update — the authoritative procedure covering NuGet package updates, database and file updates (`--kxp-update`), updating with Continuous Integration enabled (`--kxp-ci-disable`, `--kxp-ci-enable`, `--kxp-ci-store`), admin customization npm packages, and project templates.
-- **Update Xperience by Kentico (guide)**: https://docs.kentico.com/guides/development/get-started/update-xperience
-  - When to read: a quick-start walkthrough of the update flow, including a video demo and an example automation script.

--- a/plugins/kentico-project-lifecycle/skills/update-xperience/references/update-docs.md
+++ b/plugins/kentico-project-lifecycle/skills/update-xperience/references/update-docs.md
@@ -1,0 +1,15 @@
+# Update Documentation Links
+
+Fetch any link via the Kentico Docs MCP. Read only what the task needs.
+
+## Primary source
+
+- **Changelog (release notes)**: https://docs.kentico.com/changelog
+  - When to read: always — release notes for every version in the update path drive the whole update. They list breaking changes, deprecations, new object types for CI/CD, and link to pages that guide through specific feature updates. Follow those linked pages.
+
+## Update procedure
+
+- **Update Xperience by Kentico projects**: https://docs.kentico.com/documentation/developers-and-admins/installation/update-xperience-by-kentico-projects
+  - When to read: performing the update — the authoritative procedure covering NuGet package updates, database and file updates (`--kxp-update`), updating with Continuous Integration enabled (`--kxp-ci-disable`, `--kxp-ci-enable`, `--kxp-ci-store`), admin customization npm packages, and project templates.
+- **Update Xperience by Kentico (guide)**: https://docs.kentico.com/guides/development/get-started/update-xperience
+  - When to read: a quick-start walkthrough of the update flow, including a video demo and an example automation script.


### PR DESCRIPTION
## Summary

Adds a single `update-xperience` skill to the **kentico-project-lifecycle** plugin for updating an Xperience by Kentico project to a newer version. This supersedes PR #12, which should be closed.

Compared to PR #12's approach:

- **Points to the docs instead of duplicating them** — the skill is a minimal docs-pointer (in the style of `design-to-content`): release notes in the [Changelog](https://docs.kentico.com/changelog) drive the update, including following the feature-specific update guides linked from the release notes, with the [official update procedure](https://docs.kentico.com/documentation/developers-and-admins/installation/update-xperience-by-kentico-projects) as the authoritative how-to.
- **No Data API Builder** — everything needed is built into the product: CI toggling is handled by the `--kxp-ci-enable` / `--kxp-ci-disable` / `--kxp-ci-status` CLI commands (added in Refresh 31.6.0), covered by the official docs.
- **One skill, no prep stage, no context files** — packaged in the existing kentico-project-lifecycle plugin, which already configures the Kentico Docs MCP.

## Changes

- `plugins/kentico-project-lifecycle/skills/update-xperience/SKILL.md` — minimal 5-step workflow; optional `[target-version]` argument (defaults to latest)
- `plugins/kentico-project-lifecycle/skills/update-xperience/references/update-docs.md` — docs links with when-to-read notes, Changelog first
- Plugin README and root README updated with the new skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)