### PR TITLE
KX-24474 - Improve agentify skill

### DIFF
--- a/plugins/kentico-web-development/skills/agentify/assets/READINESS_REPORT_TEMPLATE.md
+++ b/plugins/kentico-web-development/skills/agentify/assets/READINESS_REPORT_TEMPLATE.md
@@ -18,7 +18,7 @@ Overall readiness: **{Ready / Mostly ready / Needs work}**
 
 - **Evidence:** {evidence supporting the status, e.g. link to file, code snippet, etc.}
 - **Gap:** {what is missing or incomplete}
-- **Recommended fix:** {concrete action; reference the template/guide used}
+- **Recommended fix:** {concrete action this skill will perform for the user, described as what will be created or changed in their project; do not reference this skill's internal template or reference files}
 
 ## Quick tip
 

--- a/plugins/kentico-web-development/skills/agentify/references/agentic-readiness-checklist.md
+++ b/plugins/kentico-web-development/skills/agentify/references/agentic-readiness-checklist.md
@@ -14,6 +14,8 @@ This checklist identifies areas which determine how well an Xperience by Kentico
 ## 2. Guidance skills
 
 - This project has a skill that provides guidance on how to handle design-related questions and tasks.
+  - The skill follows the Agent Skills specification: https://agentskills.io/specification
+  - Check each required frontmatter field.
 
 ## 3. Kentico MCPs
 

--- a/plugins/kentico-web-development/skills/agentify/references/implement-agentic-conventions.md
+++ b/plugins/kentico-web-development/skills/agentify/references/implement-agentic-conventions.md
@@ -10,7 +10,9 @@ This reference describes how to implement agentic conventions in an Xperience by
 
 ## 2. Guidance skills
 
-- Based on the AI tool the user has, create skills in correct location that provide guidance on how to handle design related questions and tasks.
+- Create an agent Skill that provides guidance on how to handle design related questions and tasks.
+- Make sure the skill follows https://agentskills.io/specification
+- Place the skill where the user's AI tool discovers skills (its skills directory); consult that tool's documentation for the exact location.
 - Use the `assets/design-conventions.TEMPLATE.md` as a template for these skills, filling in all placeholder fields with project-specific information.
 - Ask the user to provide a reference to their preferred design guidance; do not fill those skill files in on your own.
 

--- a/plugins/kentico-web-development/skills/agentify/references/implement-agentic-conventions.md
+++ b/plugins/kentico-web-development/skills/agentify/references/implement-agentic-conventions.md
@@ -10,11 +10,11 @@ This reference describes how to implement agentic conventions in an Xperience by
 
 ## 2. Guidance skills
 
-- Create an agent Skill that provides guidance on how to handle design related questions and tasks.
-- Make sure the skill follows https://agentskills.io/specification
+- Create an Agent Skill that provides guidance on how to handle design-related questions and tasks.
+- Make sure the skill follows the Agent Skills specification: https://agentskills.io/specification
 - Place the skill where the user's AI tool discovers skills (its skills directory); consult that tool's documentation for the exact location.
-- Use the `assets/design-conventions.TEMPLATE.md` as a template for these skills, filling in all placeholder fields with project-specific information.
-- Ask the user to provide a reference to their preferred design guidance; do not fill those skill files in on your own.
+- Use the `assets/design-conventions.TEMPLATE.md` as a template for this skill, filling in all placeholder fields with project-specific information.
+- Ask the user to provide a reference to their preferred design guidance; do not fill this skill file in on your own.
 
 ## 3. Kentico MCPs
 


### PR DESCRIPTION
## Summary

Addresses feedback from testing the `agentify` skill:

- **Wording**: The readiness report's "Recommended fix" and the implementation reference now make clear the agent creates the resources in the user's project itself, without referencing the skill's internal template files (which marketplace plugin users cannot easily open).
- **Copilot design skill**: The guidance-skills section now explicitly requires creating an Agent Skill per the [Agent Skills specification](https://agentskills.io/specification) instead of a plain Copilot instruction file (`.github/copilot-instructions.md` / `.github/instructions/*`).
- **Frontmatter audit**: The readiness checklist now checks the design skill against the Agent Skills specification, verifying each required frontmatter field so partially missing frontmatter (e.g. only `description` missing) is detected and reported as partial.

## Following the conventions

- [x] The resource targets **Kentico Xperience developers** and is meant to be invoked by an AI assistant (not aimed at marketing, sales, or support).
- [x] The resource does **not** duplicate the Kentico documentation — it links the relevant docs pages and adds context instead.
- [x] A new resource is genuinely needed — the same result can't be achieved with an existing resource, a docs link, or a well-written prompt.
- [x] The resource avoids features or fields specific to a single AI tool, so it works across different AI assistants.
- [x] Plugin and marketplace versions are bumped per the [versioning rules](../docs/Contributing-Setup.md) — not bumped here; this PR targets the `feature/KX-24345_Agentic_code_writing` feature branch, so the bump should happen when that branch merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)