### PR TITLE
KX-24477 Add missing docs pages to design-to-content references

### DIFF
--- a/plugins/kentico-web-development/skills/design-to-content/references/content-modeling-docs.md
+++ b/plugins/kentico-web-development/skills/design-to-content/references/content-modeling-docs.md
@@ -57,6 +57,8 @@ The main content-modeling guide. Follow in order for a full model.
   - When to read: worked example with a relationship diagram (Article, Author, Media, Category).
 - **Model a Product content type**: https://docs.kentico.com/guides/architecture/content-modeling/model-reusable-content/model-a-reusable-product
   - When to read: composing a complex type from smaller reusable types.
+- **Model a reusable Product SKU**: https://docs.kentico.com/guides/architecture/content-modeling/model-reusable-content/model-a-reusable-product-sku
+  - When to read: commerce/SKU products; field naming conventions (type-prefixed, globally unique code names) and complete field definitions with data type + form component pairs.
 
 ## Website content examples
 
@@ -79,13 +81,17 @@ The main content-modeling guide. Follow in order for a full model.
 ## Reference docs (building blocks)
 
 - **Content types**: https://docs.kentico.com/documentation/developers-and-admins/development/content-types
-  - When to read: creating/configuring types, field naming, linking items, file uploads.
+  - When to read: creating/configuring types, linking items, file uploads. Always read the "Field naming guidelines" section — field code names must be globally unique and prefixed with the content type name (e.g. `ArticleTitle`).
 - **Reusable field schemas**: https://docs.kentico.com/documentation/developers-and-admins/development/content-types/reusable-field-schemas
   - When to read: sharing a set of fields across multiple types.
 - **Field editor**: https://docs.kentico.com/documentation/developers-and-admins/customization/field-editor
   - When to read: understanding fields = name + data type + form component.
 - **Data type management**: https://docs.kentico.com/documentation/developers-and-admins/customization/field-editor/data-type-management
-  - When to read: choosing a field's data type.
+  - When to read: choosing a field's data type. Use the correct type (Integer/Decimal number, Date, Boolean, …) — never Text for numeric or date values.
+- **Admin UI form components (reference)**: https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/reference-admin-ui-form-components
+  - When to read: assigning form components to fields — the authoritative list of component names and their matching field data types (e.g. Combined content selector ↔ Pages and reusable content). Use exact names from this page only.
+- **UI form component validation rules**: https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/ui-form-component-validation-rules
+  - When to read: adding validation/constraints to fields.
 - **Content hub**: https://docs.kentico.com/documentation/business-users/content-hub
   - When to read: where reusable content lives.
 - **Content items**: https://docs.kentico.com/documentation/business-users/content-hub/content-items

--- a/plugins/kentico-web-development/skills/design-to-content/references/content-modeling-docs.md
+++ b/plugins/kentico-web-development/skills/design-to-content/references/content-modeling-docs.md
@@ -58,7 +58,7 @@ The main content-modeling guide. Follow in order for a full model.
 - **Model a Product content type**: https://docs.kentico.com/guides/architecture/content-modeling/model-reusable-content/model-a-reusable-product
   - When to read: composing a complex type from smaller reusable types.
 - **Model a reusable Product SKU**: https://docs.kentico.com/guides/architecture/content-modeling/model-reusable-content/model-a-reusable-product-sku
-  - When to read: commerce/SKU products; field naming conventions (type-prefixed, globally unique code names) and complete field definitions with data type + form component pairs.
+  - When to read: modeling commerce/SKU products; field naming conventions.
 
 ## Website content examples
 
@@ -81,15 +81,15 @@ The main content-modeling guide. Follow in order for a full model.
 ## Reference docs (building blocks)
 
 - **Content types**: https://docs.kentico.com/documentation/developers-and-admins/development/content-types
-  - When to read: creating/configuring types, linking items, file uploads. Always read the "Field naming guidelines" section — field code names must be globally unique and prefixed with the content type name (e.g. `ArticleTitle`).
+  - When to read: creating/configuring types, field naming guidelines, linking items, file uploads.
 - **Reusable field schemas**: https://docs.kentico.com/documentation/developers-and-admins/development/content-types/reusable-field-schemas
   - When to read: sharing a set of fields across multiple types.
 - **Field editor**: https://docs.kentico.com/documentation/developers-and-admins/customization/field-editor
   - When to read: understanding fields = name + data type + form component.
 - **Data type management**: https://docs.kentico.com/documentation/developers-and-admins/customization/field-editor/data-type-management
-  - When to read: choosing a field's data type. Use the correct type (Integer/Decimal number, Date, Boolean, …) — never Text for numeric or date values.
+  - When to read: choosing a field's data type.
 - **Admin UI form components (reference)**: https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/reference-admin-ui-form-components
-  - When to read: assigning form components to fields — the authoritative list of component names and their matching field data types (e.g. Combined content selector ↔ Pages and reusable content). Use exact names from this page only.
+  - When to read: assigning form components to fields — authoritative names of components and their matching data types.
 - **UI form component validation rules**: https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/ui-form-component-validation-rules
   - When to read: adding validation/constraints to fields.
 - **Content hub**: https://docs.kentico.com/documentation/business-users/content-hub


### PR DESCRIPTION
## Summary

Testing of the design-to-content skill ([KX-24477 findings](https://kentico.atlassian.net/browse/KX-24477?focusedCommentId=680442)) showed agents hallucinating form component / data type names, reusing unprefixed field code names, and assigning Text to numeric fields. This adds the docs pages that cover those areas:

- **Admin UI form components (reference)** – authoritative list of component names and their matching field data types.
- **Model a reusable Product SKU** – worked example with type-prefixed, globally unique field code names and full field definitions.
- **UI form component validation rules** – field validation/constraints.

Also strengthens the "When to read" notes for the Content types (field naming guidelines) and Data type management (no Text for numbers/dates) entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)