### PR TITLE
KX-24476 Harden content-retrieval skill description for proactive triggering

### DIFF
--- a/plugins/kentico-web-development/skills/content-retrieval/SKILL.md
+++ b/plugins/kentico-web-development/skills/content-retrieval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: content-retrieval
-description: "Content retrieval in Xperience by Kentico — best practices for retrieving content (pages, reusable content items, reusable-schema items) in code. Use whenever working with code that fetches content, turning a Combined content selector / Page selector selection into data, or debugging slow content retrieval."
+description: "Content retrieval in Xperience by Kentico — best practices for retrieving content (pages, reusable content items, reusable-schema items) in code. Proactively read this before writing or modifying any code that retrieves content (IContentRetriever, ContentItemQueryBuilder), turning a Combined content selector / Page selector selection into data, or debugging slow content retrieval."
 compatibility: "Requires Kentico Docs MCP"
 ---
 


### PR DESCRIPTION
## Motivation

Agents were skipping the content-retrieval skill when the solution already contained enough retrieval code — they treated existing files as sufficient context and never read the best practices.

## What changed

Reworded the skill description from a topic-match trigger ("Use whenever working with code that fetches content") to an action gate: "Proactively read this before writing or modifying any code that retrieves content (IContentRetriever, ContentItemQueryBuilder), ...". The explicit API names act as literal-token triggers when an agent is editing existing retrieval code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)