### PR TITLE
KX-24967 Add automation-condition skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,22 +6,22 @@
   },
   "metadata": {
     "description": "Agent plugins that teach AI coding assistants how to build, migrate, and maintain Xperience by Kentico projects",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "pluginRoot": "./plugins"
   },
   "plugins": [
     {
       "name": "kentico-digital-experience",
       "source": "./plugins/kentico-digital-experience",
-      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions that add custom step types to the Automation Builder",
-      "version": "1.0.0",
+      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions and conditions that add custom step types to the Automation Builder",
+      "version": "1.1.0",
       "author": {
         "name": "Kentico"
       },
       "homepage": "https://github.com/Kentico/xperience-by-kentico-kenticopilot/tree/main/plugins/kentico-digital-experience",
       "repository": "https://github.com/Kentico/xperience-by-kentico-kenticopilot",
       "license": "MIT",
-      "keywords": ["kentico", "xperience", "digital-experience", "automation", "automation-builder", "automation-action", "marketing", "cms"],
+      "keywords": ["kentico", "xperience", "digital-experience", "automation", "automation-builder", "automation-action", "automation-condition", "marketing", "cms"],
       "strict": false
     },
     {

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "kentico-digital-experience",
       "source": "./kentico-digital-experience",
-      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions and conditions that add custom step types to the Automation Builder" and Automation triggers that start processes from application code",
+      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions and conditions that add custom step types to the Automation Builder and Automation triggers that start processes from application code",
       "version": "1.1.0",
       "author": {
         "name": "Kentico"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "xperience-by-kentico-kenticopilot",
   "metadata": {
     "description": "Agent plugins that teach AI coding assistants how to build, migrate, and maintain Xperience by Kentico projects",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "pluginRoot": "./plugins"
   },
   "owner": {
@@ -13,15 +13,15 @@
     {
       "name": "kentico-digital-experience",
       "source": "./kentico-digital-experience",
-      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions that add custom step types to the Automation Builder",
-      "version": "1.0.0",
+      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions and conditions that add custom step types to the Automation Builder",
+      "version": "1.1.0",
       "author": {
         "name": "Kentico"
       },
       "homepage": "https://github.com/Kentico/xperience-by-kentico-kenticopilot/tree/main/plugins/kentico-digital-experience",
       "repository": "https://github.com/Kentico/xperience-by-kentico-kenticopilot",
       "license": "MIT",
-      "keywords": ["kentico", "xperience", "digital-experience", "automation", "automation-builder", "automation-action", "marketing", "cms"]
+      "keywords": ["kentico", "xperience", "digital-experience", "automation", "automation-builder", "automation-action", "automation-condition", "marketing", "cms"]
     },
     {
       "name": "kentico-web-development",

--- a/plugins/kentico-digital-experience/README.md
+++ b/plugins/kentico-digital-experience/README.md
@@ -2,13 +2,16 @@
 
 Extend the digital marketing features of Xperience by Kentico with custom components, written by your AI coding assistant.
 
-Marketers configure these features using the component types available to them. When they need behavior Xperience doesn't provide out of the box, such as posting to a chat channel or calling an internal service, a developer adds a custom component. This plugin hands that work to your coding assistant. You explain what the component does and which settings marketers control, and the agent writes the implementation together with the registration that makes it available in the admin UI.
+Marketers configure these features using the component types available to them. When they need behavior Xperience doesn't provide out of the box, such as posting to a chat channel, calling an internal service, or branching a process on data Xperience doesn't track, a developer adds a custom component. This plugin hands that work to your coding assistant. You explain what the component does and which settings marketers control, and the agent writes the implementation together with the registration that makes it available in the admin UI.
 
 ## Choose a skill
 
 | Skill | Use it to |
 |---|---|
 | `automation-action` | Implement and register a custom automation action, with optional marketer-configurable properties |
+| `automation-condition` | Implement and register a custom automation condition that branches a process, with optional marketer-configurable properties |
+
+The two skills cover the two kinds of custom step. An action *does* something for the contact that reaches it. A condition *decides* which of two paths that contact takes, and changes nothing.
 
 For the other kinds of automation customization, see the [customization overview](https://docs.kentico.com/x/automation_custom_xp).
 
@@ -21,6 +24,10 @@ For the other kinds of automation customization, see the [customization overview
 - An AI coding assistant with this plugin installed
 - The [Documentation MCP server](https://docs.kentico.com/x/mcp_server_xp), configured as described in [MCP setup](./MCP-setup.md)
 - A description of what the step does, and of any settings marketers need to change
+
+Additionally, `automation-condition` requires:
+
+- A description of the branch logic — what makes the condition true, what data it reads, and which path each outcome leads to
 
 ## Install
 
@@ -49,6 +56,28 @@ This sequence produces one working action, configurable by marketers. See the ot
 5. Build the project and restart the application, then open the **Automation** application and add your step to a process. Confirm the step appears under its display name and that its properties render in the configuration dialog.
 
 At this point the step is available to every marketer working in the Automation Builder, and it runs for each contact that reaches it.
+
+## Build your first condition
+
+This sequence produces one working condition that marketers can drop into a process to split it in two.
+
+1. Open the solution containing your Xperience web project in your AI coding assistant.
+
+2. Describe what makes the condition true and what data it reads. State which outcome belongs on which branch if it isn't obvious.
+
+   ```text
+   /automation-condition
+
+   Create a condition that is true when the contact has an active
+   subscription in our billing service. Marketers need to pick which
+   subscription tier counts as active.
+   ```
+
+3. Answer the design questions. The agent reads the current Xperience documentation and studies how your project is organized, then confirms the design before writing anything. Expect it to ask what should happen when the data it needs is missing.
+
+4. Review the generated code. The agent reports which files it created. Read [Review the output](#review-the-output).
+
+5. Build the project and restart the application, then open the **Automation** application and add your condition to a process. Confirm it appears under its display name, that its properties render in the configuration dialog, and that both the true and the false branch lead where you expect.
 
 ## Common tasks
 
@@ -83,6 +112,37 @@ Add a retry-count setting to the CrmSyncAction, editable by marketers,
 with a default of 3 and a maximum of 10.
 ```
 
+### Add an automation condition with no settings
+
+The agent skips the properties class entirely.
+
+```text
+/automation-condition
+
+Add a condition that is true when the contact's email address uses one
+of our internal domains. No marketer-facing settings.
+```
+
+### Branch on data produced by an earlier step
+
+Name the action that stores the data. The agent wires the condition to read the same process data type instead of fetching the value again.
+
+```text
+/automation-condition
+
+Add a condition that is true when the lead score stored by the
+LeadScoringAction is above a threshold the marketer sets.
+```
+
+### Add a property to an existing condition
+
+Describe the condition and the setting. The agent finds the existing classes and extends them rather than starting over.
+
+```text
+Add a country setting to the HasActiveSubscriptionCondition, editable by
+marketers as a dropdown, so the check can be limited to one market.
+```
+
 ## Write effective prompts
 
 Both of these prompts produce a working output. However, providing the agent with more context significantly reduces guesswork and increases output quality and standards adherence. Compare:
@@ -91,6 +151,8 @@ Both of these prompts produce a working output. However, providing the agent wit
 |---|---|
 | `Create an action that sends an email` | The agent works out the recipient, the source of the content, and which parts marketers control. Expect several rounds of questions. |
 | `Create an action that sends the contact a transactional email chosen by the marketer from a dropdown of published email templates` | The agent proposes a design right away and asks only about what you left open. |
+| `Create a condition that checks the contact's subscription` | The agent works out where the subscription data lives, what counts as a match, and which outcome belongs on the true branch. Expect several rounds of questions. |
+| `Create a condition that is true when the contact has an active subscription of a tier the marketer picks from a dropdown, read from our billing API` | The agent proposes a design right away and asks only about what you left open. |
 
 > [!TIP]
 > The same applies to every KentiCopilot skill. See [Write specific prompts](../../docs/Usage-Guide.md#write-specific-prompts) for the general guidance, including the habits that slow a session down.
@@ -102,6 +164,10 @@ Treat generated code the way you'd treat a pull request from someone new to the 
 **Form annotation namespace** -- The [form component](https://docs.kentico.com/x/8ASiCQ) attributes that build the configuration dialog need to come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces. An obsolete Form Builder namespace, `Kentico.Forms.Web.Mvc`, contains attributes with the same names. Check the `using` directives on the properties class.
 
 **Execution time limit** -- Actions are cancelled after two minutes, so a step calling a slow external service can be cut off mid-run. If the generated code talks to anything outside the application, read [Best practices](https://docs.kentico.com/x/automation_custom_steps_xp) for the timeout behavior and what to do instead.
+
+**Side effects in a condition** -- A condition evaluates and returns a result, nothing more. The same contact can be evaluated more than once, so anything the generated `Evaluate` method writes, sends, or stores happens repeatedly. Move that work into an action.
+
+**The false branch as the failure path** -- A condition that times out or throws resolves to `false`, which makes the false branch the path contacts take when something goes wrong, not only when the answer is genuinely no. Check that the branch is a safe place to land.
 
 Other things to keep an eye on during review:
 

--- a/plugins/kentico-digital-experience/README.md
+++ b/plugins/kentico-digital-experience/README.md
@@ -125,7 +125,7 @@ of our internal domains. No marketer-facing settings.
 
 ### Branch on data produced by an earlier step
 
-Name the action that stores the data. The agent wires the condition to read the same process data type instead of fetching the value again.
+Name the action that stores the data, so the agent wires the condition to the same process data type.
 
 ```text
 /automation-condition
@@ -163,11 +163,11 @@ Treat generated code the way you'd treat a pull request from someone new to the 
 
 **Form annotation namespace** -- The [form component](https://docs.kentico.com/x/8ASiCQ) attributes that build the configuration dialog need to come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces. An obsolete Form Builder namespace, `Kentico.Forms.Web.Mvc`, contains attributes with the same names. Check the `using` directives on the properties class.
 
-**Execution time limit** -- Actions are cancelled after two minutes, so a step calling a slow external service can be cut off mid-run. If the generated code talks to anything outside the application, read [Best practices](https://docs.kentico.com/x/automation_custom_steps_xp) for the timeout behavior and what to do instead.
+**Execution time limit** -- Custom steps are cancelled after two minutes, an action's `Execute` and a condition's `Evaluate` alike, so a step calling a slow external service can be cut off mid-run. If the generated code talks to anything outside the application, read [Best practices](https://docs.kentico.com/x/automation_custom_steps_xp) for the timeout behavior and what to do instead.
 
 **Side effects in a condition** -- A condition evaluates and returns a result, nothing more. The same contact can be evaluated more than once, so anything the generated `Evaluate` method writes, sends, or stores happens repeatedly. Move that work into an action.
 
-**The false branch as the failure path** -- A condition that times out or throws resolves to `false`, which makes the false branch the path contacts take when something goes wrong, not only when the answer is genuinely no. Check that the branch is a safe place to land.
+**Failures resolve to `false`** -- An unhandled exception and the two-minute timeout both make the condition return `false`, indistinguishable from a genuine no. Check that the generated `Evaluate` handles the failures it can, logs them, and returns a value it chose deliberately.
 
 Other things to keep an eye on during review:
 

--- a/plugins/kentico-digital-experience/skills/automation-condition/SKILL.md
+++ b/plugins/kentico-digital-experience/skills/automation-condition/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: "automation-condition"
+description: "Reference for implementing custom automation process conditions in Xperience by Kentico. Use whenever the user wants to branch an automation process on custom logic — a class that evaluates every contact reaching the step and sends it down the true or the false path, optionally configurable by marketers through properties."
+compatibility: "Requires Kentico Docs MCP"
+---
+
+This skill points you to Kentico's automation-customization documentation. Use it to implement a custom automation process condition.
+
+## Pieces of a custom condition
+
+- **Condition class** – inherits `AutomationCondition` (no configuration) or `AutomationCondition<TProperties>` (marketer-configurable); implements the logic in `Evaluate`, which returns `true` for the true branch and `false` for the false branch.
+- **Properties class** – implements `IAutomationConditionProperties`; public properties annotated with admin UI form components define the configuration dialog.
+- **Registration** – the `RegisterAutomationCondition` assembly attribute (identifier, display name, icon, description) makes the condition appear in the Automation Builder.
+- **Runtime context** – `AutomationProcessContext` gives access to the processed contact, the process, and trigger data.
+- **Process data** – `IAutomationProcessData` implementations carry typed data from earlier steps; a condition reads that data, it never writes it.
+
+## How to use
+
+- Read `references/docs.md` and fetch the docs pages listed there.
+
+## Gotcha
+
+- Keep `Evaluate` read-only and idempotent — a condition can be re-evaluated for the same contact, so side effects belong in an action.
+- Both an unhandled exception and the two-minute timeout resolve the condition to `false`, so design the false branch as the safe fallback path.
+- Form-component and validation attributes come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces — never from `Kentico.Forms.Web.Mvc`, an obsolete Form Builder namespace with matching class names.
+- Prefer using `ILogger<T>` for logging instead of `EventLogService`.

--- a/plugins/kentico-digital-experience/skills/automation-condition/SKILL.md
+++ b/plugins/kentico-digital-experience/skills/automation-condition/SKILL.md
@@ -21,6 +21,6 @@ This skill points you to Kentico's automation-customization documentation. Use i
 ## Gotcha
 
 - Keep `Evaluate` read-only and idempotent — a condition can be re-evaluated for the same contact, so side effects belong in an action.
-- Both an unhandled exception and the two-minute timeout resolve the condition to `false`, so design the false branch as the safe fallback path.
+- Both an unhandled exception and the two-minute timeout resolve the condition to `false`, indistinguishable from a genuine no — handle the failures you can inside `Evaluate`, log them, and return a deliberate result.
 - Form-component and validation attributes come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces — never from `Kentico.Forms.Web.Mvc`, an obsolete Form Builder namespace with matching class names.
-- Prefer using `ILogger<T>` for logging instead of `EventLogService`.
+- Use `ILogger<T>` for logging. `EventLogService` is obsolete — don't use it.

--- a/plugins/kentico-digital-experience/skills/automation-condition/references/docs.md
+++ b/plugins/kentico-digital-experience/skills/automation-condition/references/docs.md
@@ -1,0 +1,23 @@
+# Documentation links
+
+Fetch any link via the Kentico Docs MCP. Read only what the task needs.
+
+## Automation customization
+
+- **Custom automation steps**: <https://docs.kentico.com/documentation/developers-and-admins/digital-marketing-setup/automation-customization/automation-custom-steps>
+  - When to read: always, first. The authoritative reference — base classes, full examples, condition properties, registration, branching, runtime context (processed contact, trigger data, process data), and best practices (read-only evaluation, timeouts, error handling, data protection, versioning, property guidelines, dependency injection).
+- **Automation customization overview**: <https://docs.kentico.com/documentation/developers-and-admins/digital-marketing-setup/automation-customization>
+  - When to read: to see what kinds of custom automation components exist and where conditions fit.
+- **Automation overview**: <https://docs.kentico.com/documentation/business-users/digital-marketing/automation>
+  - When to read: to understand the marketer's mental model — triggers, step types, branching, contact mapping — before designing a condition.
+
+## Admin UI form components (for the properties class)
+
+- **Form components reference**: <https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/reference-admin-ui-form-components>
+  - When to read: when picking editing components for condition properties.
+- **Validation rules**: <https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/ui-form-component-validation-rules.html>
+  - When to read: when constraining property values declaratively or defining a custom rule.
+- **Visibility conditions**: <https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/ui-form-component-visibility-conditions.html>
+  - When to read: when a property should show or hide based on another property's value.
+- **Configure editing component state**: <https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/editing-components/configure-editing-component-state>
+  - When to read: when cross-field dependencies need a component configurator — e.g. a dropdown whose options depend on another property.


### PR DESCRIPTION
## Summary

Adds an `automation-condition` skill to the `kentico-digital-experience` plugin, alongside the existing `automation-action`. Xperience's automation customization supports custom conditions — read-only steps that branch a process on custom logic — and there was no skill for them.

## Changes

- **New skill** `plugins/kentico-digital-experience/skills/automation-condition/`
  - `SKILL.md` — same shape as `automation-action`: quoted frontmatter (`name`, `description`, `compatibility`), no H1, `## Pieces of a custom condition`, `## How to use`, `## Gotcha`. No code samples; API detail is delegated to the docs via MCP.
  - `references/docs.md` — same entry format and the same 7 canonical URLs as the action skill, with the "when to read" text rewritten for conditions.
- **Plugin README** — full parity with `automation-action`: intro sentence, skill table row plus a line on how the two skills relate, a condition line under Requirements, `## Build your first condition`, 3 new Common tasks entries, 2 prompt-table rows, and 2 new Review-the-output notes (side effects in `Evaluate`, the false branch as the failure path).
- **Both marketplace manifests** — `metadata.version` 2.0.0 → 2.0.1 (patch, change inside a plugin), plugin `version` 1.0.0 → 1.1.0 (minor, additive skill), description extended, `automation-condition` keyword added. Each file's existing differences (`source` prefix, `strict` field) are preserved.

## API facts

Taken from the `automation-custom-steps` docs page — conditions are documented on the same page as actions: `AutomationCondition` / `AutomationCondition<TProperties>`, `IAutomationConditionProperties`, `RegisterAutomationCondition`, `Evaluate` returning `Task<bool>`, must be read-only and idempotent, and both timeouts and unhandled exceptions resolve to `false`.

## Verification

- Both manifests parse as valid JSON; `metadata.version` matches between them and is bare semver.
- The condition skill's doc URL set is byte-identical to the shipped action skill's.
- Not smoke-tested against a live Xperience project — none available in this checkout.

## Note

`feature/KX-24964_Custom_trigger` bumps to the same 1.1.0 / 2.0.1 and edits the same README regions, so whichever branch lands second needs those three files reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)