### PR TITLE
KX-24963 - Custom automation skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,22 +6,22 @@
   },
   "metadata": {
     "description": "Agent plugins that teach AI coding assistants how to build, migrate, and maintain Xperience by Kentico projects",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "pluginRoot": "./plugins"
   },
   "plugins": [
     {
       "name": "kentico-digital-experience",
       "source": "./plugins/kentico-digital-experience",
-      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions that add custom step types to the Automation Builder",
-      "version": "1.0.0",
+      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions that add custom step types to the Automation Builder and Automation triggers that start processes from application code",
+      "version": "1.1.0",
       "author": {
         "name": "Kentico"
       },
       "homepage": "https://github.com/Kentico/xperience-by-kentico-kenticopilot/tree/main/plugins/kentico-digital-experience",
       "repository": "https://github.com/Kentico/xperience-by-kentico-kenticopilot",
       "license": "MIT",
-      "keywords": ["kentico", "xperience", "digital-experience", "automation", "automation-builder", "automation-action", "marketing", "cms"],
+      "keywords": ["kentico", "xperience", "digital-experience", "automation", "automation-builder", "automation-action", "automation-trigger", "marketing", "cms"],
       "strict": false
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,22 +6,22 @@
   },
   "metadata": {
     "description": "Agent plugins that teach AI coding assistants how to build, migrate, and maintain Xperience by Kentico projects",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "pluginRoot": "./plugins"
   },
   "plugins": [
     {
       "name": "kentico-digital-experience",
       "source": "./plugins/kentico-digital-experience",
-      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions that add custom step types to the Automation Builder",
-      "version": "1.0.0",
+      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions and conditions that add custom step types to the Automation Builder",
+      "version": "1.1.0",
       "author": {
         "name": "Kentico"
       },
       "homepage": "https://github.com/Kentico/xperience-by-kentico-kenticopilot/tree/main/plugins/kentico-digital-experience",
       "repository": "https://github.com/Kentico/xperience-by-kentico-kenticopilot",
       "license": "MIT",
-      "keywords": ["kentico", "xperience", "digital-experience", "automation", "automation-builder", "automation-action", "marketing", "cms"],
+      "keywords": ["kentico", "xperience", "digital-experience", "automation", "automation-builder", "automation-action", "automation-condition", "marketing", "cms"],
       "strict": false
     },
     {

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,4 @@ Fill in the sections that apply and delete the ones that don't.
 - [ ] The resource does **not** duplicate the Kentico documentation — it links the relevant docs pages and adds context instead.
 - [ ] A new resource is genuinely needed — the same result can't be achieved with an existing resource, a docs link, or a well-written prompt.
 - [ ] The resource avoids features or fields specific to a single AI tool, so it works across different AI assistants.
-- [ ] Plugin and marketplace versions are bumped per the [versioning rules](../docs/Contributing-Setup.md) — any plugin change bumps the marketplace version at least by a patch, and both marketplace files match.
+- [ ] Plugin and marketplace versions are bumped per the [versioning rules](https://github.com/Kentico/xperience-by-kentico-kenticopilot/blob/main/docs/Contributing-Setup.md#versioning-the-marketplace-manifests) — any plugin change bumps the marketplace version at least by a patch, and both marketplace files match.

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "xperience-by-kentico-kenticopilot",
   "metadata": {
     "description": "Agent plugins that teach AI coding assistants how to build, migrate, and maintain Xperience by Kentico projects",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "pluginRoot": "./plugins"
   },
   "owner": {
@@ -13,15 +13,15 @@
     {
       "name": "kentico-digital-experience",
       "source": "./kentico-digital-experience",
-      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions that add custom step types to the Automation Builder",
-      "version": "1.0.0",
+      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions that add custom step types to the Automation Builder and Automation triggers that start processes from application code",
+      "version": "1.1.0",
       "author": {
         "name": "Kentico"
       },
       "homepage": "https://github.com/Kentico/xperience-by-kentico-kenticopilot/tree/main/plugins/kentico-digital-experience",
       "repository": "https://github.com/Kentico/xperience-by-kentico-kenticopilot",
       "license": "MIT",
-      "keywords": ["kentico", "xperience", "digital-experience", "automation", "automation-builder", "automation-action", "marketing", "cms"]
+      "keywords": ["kentico", "xperience", "digital-experience", "automation", "automation-builder", "automation-action", "automation-trigger", "marketing", "cms"]
     },
     {
       "name": "kentico-web-development",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "kentico-digital-experience",
       "source": "./kentico-digital-experience",
-      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions and conditions that add custom step types to the Automation Builder" and Automation triggers that start processes from application code",
+      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions and conditions that add custom step types to the Automation Builder and Automation triggers that start processes from application code",
       "version": "1.1.0",
       "author": {
         "name": "Kentico"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "xperience-by-kentico-kenticopilot",
   "metadata": {
     "description": "Agent plugins that teach AI coding assistants how to build, migrate, and maintain Xperience by Kentico projects",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "pluginRoot": "./plugins"
   },
   "owner": {
@@ -13,15 +13,15 @@
     {
       "name": "kentico-digital-experience",
       "source": "./kentico-digital-experience",
-      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions that add custom step types to the Automation Builder",
-      "version": "1.0.0",
+      "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions and conditions that add custom step types to the Automation Builder",
+      "version": "1.1.0",
       "author": {
         "name": "Kentico"
       },
       "homepage": "https://github.com/Kentico/xperience-by-kentico-kenticopilot/tree/main/plugins/kentico-digital-experience",
       "repository": "https://github.com/Kentico/xperience-by-kentico-kenticopilot",
       "license": "MIT",
-      "keywords": ["kentico", "xperience", "digital-experience", "automation", "automation-builder", "automation-action", "marketing", "cms"]
+      "keywords": ["kentico", "xperience", "digital-experience", "automation", "automation-builder", "automation-action", "automation-condition", "marketing", "cms"]
     },
     {
       "name": "kentico-web-development",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,3 @@
 # KentiCopilot GH repository
 
-Read [`Contributing-Setup.md`](../docs/Contributing-Setup.md) to see how to work in this repository.
+Read [`Contributing-Setup.md`](./docs/Contributing-Setup.md) to see how to work in this repository.

--- a/plugins/kentico-digital-experience/README.md
+++ b/plugins/kentico-digital-experience/README.md
@@ -2,13 +2,16 @@
 
 Extend the digital marketing features of Xperience by Kentico with custom components, written by your AI coding assistant.
 
-Marketers configure these features using the component types available to them. When they need behavior Xperience doesn't provide out of the box, such as posting to a chat channel or calling an internal service, a developer adds a custom component. This plugin hands that work to your coding assistant. You explain what the component does and which settings marketers control, and the agent writes the implementation together with the registration that makes it available in the admin UI.
+Marketers configure these features using the component types available to them. When they need behavior Xperience doesn't provide out of the box, such as posting to a chat channel, calling an internal service, or starting a process the moment an order is paid, a developer adds a custom component — a step inside a process, or the trigger that starts it. This plugin hands that work to your coding assistant. You explain what the component does and which settings marketers control, and the agent writes the implementation together with the registration that makes it available in the admin UI.
 
 ## Choose a skill
 
 | Skill | Use it to |
 |---|---|
 | `automation-action` | Implement and register a custom automation action, with optional marketer-configurable properties |
+| `automation-trigger` | Implement and register a custom automation trigger, and fire it from your application code |
+
+The two skills meet in one process: a trigger decides when the process starts and what data it carries, and actions are the steps that run afterwards, reading that data as they go. Build the trigger first when the starting event is the custom part.
 
 For the other kinds of automation customization, see the [customization overview](https://docs.kentico.com/x/automation_custom_xp).
 
@@ -20,7 +23,12 @@ For the other kinds of automation customization, see the [customization overview
 - An Xperience by Kentico project with [Automation](https://docs.kentico.com/x/automation_xp) in use
 - An AI coding assistant with this plugin installed
 - The [Documentation MCP server](https://docs.kentico.com/x/mcp_server_xp), configured as described in [MCP setup](./MCP-setup.md)
-- A description of what the step does, and of any settings marketers need to change
+- A description of what the component does, and of any settings marketers need to change
+
+Additionally, `automation-trigger` requires:
+
+- The code path that should start the process — an event handler, a controller or webhook endpoint, or a scheduled task
+- The contact the process applies to, and any data the trigger passes into it
 
 ## Install
 
@@ -49,6 +57,29 @@ This sequence produces one working action, configurable by marketers. See the ot
 5. Build the project and restart the application, then open the **Automation** application and add your step to a process. Confirm the step appears under its display name and that its properties render in the configuration dialog.
 
 At this point the step is available to every marketer working in the Automation Builder, and it runs for each contact that reaches it.
+
+## Build your first trigger
+
+A trigger is two halves: the class marketers select in the Automation Builder, and the call in your code that fires it. The agent writes both.
+
+1. Describe the event, the data it carries, and where in the code it happens.
+
+   ```text
+   /automation-trigger
+
+   Create a trigger that starts a process when a customer completes a
+   purchase, carrying the order number, total, and currency. Marketers
+   need to set a minimum order total. Fire it from the checkout
+   controller after the payment is confirmed.
+   ```
+
+2. Answer the design questions. Expect the agent to confirm which contact the trigger applies to and how the process should behave when the same contact purchases twice.
+
+3. Review the generated code, including the dispatch call the agent added to your own class. Read [Review the output](#review-the-output).
+
+4. Build the project and restart the application, then open the **Automation** application and create a process that starts from your trigger.
+
+5. Exercise the code path — place an order, raise the event, or run the scheduled task — and confirm the process starts for the expected contact.
 
 ## Common tasks
 
@@ -83,6 +114,28 @@ Add a retry-count setting to the CrmSyncAction, editable by marketers,
 with a default of 3 and a maximum of 10.
 ```
 
+### Pass data from a trigger into the process
+
+Data set when the trigger fires stays available to every step of the process.
+
+```text
+/automation-trigger
+
+Extend the PurchaseTrigger to carry the order number and the sales
+channel, and read both in the CrmSyncAction step.
+```
+
+### Fire an existing trigger on a schedule
+
+Time-based automation is a scheduled task that fires the trigger for each matching contact.
+
+```text
+/automation-trigger
+
+Add a scheduled task that fires the SubscriptionExpiringTrigger once a
+day for every contact whose subscription ends within seven days.
+```
+
 ## Write effective prompts
 
 Both of these prompts produce a working output. However, providing the agent with more context significantly reduces guesswork and increases output quality and standards adherence. Compare:
@@ -91,6 +144,8 @@ Both of these prompts produce a working output. However, providing the agent wit
 |---|---|
 | `Create an action that sends an email` | The agent works out the recipient, the source of the content, and which parts marketers control. Expect several rounds of questions. |
 | `Create an action that sends the contact a transactional email chosen by the marketer from a dropdown of published email templates` | The agent proposes a design right away and asks only about what you left open. |
+| `Create a trigger for purchases` | The agent works out the event, the data the process needs, and which class fires it. Expect several rounds of questions. |
+| `Create a trigger fired from OrderController.Confirm that carries the order number and total, and only starts the process above a marketer-set minimum` | The agent knows the firing location, the payload, and the one marketer-facing setting. |
 
 > [!TIP]
 > The same applies to every KentiCopilot skill. See [Write specific prompts](../../docs/Usage-Guide.md#write-specific-prompts) for the general guidance, including the habits that slow a session down.
@@ -101,7 +156,13 @@ Treat generated code the way you'd treat a pull request from someone new to the 
 
 **Form annotation namespace** -- The [form component](https://docs.kentico.com/x/8ASiCQ) attributes that build the configuration dialog need to come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces. An obsolete Form Builder namespace, `Kentico.Forms.Web.Mvc`, contains attributes with the same names. Check the `using` directives on the properties class.
 
-**Execution time limit** -- Actions are cancelled after two minutes, so a step calling a slow external service can be cut off mid-run. If the generated code talks to anything outside the application, read [Best practices](https://docs.kentico.com/x/automation_custom_steps_xp) for the timeout behavior and what to do instead.
+**Execution time limit** -- Actions are cancelled after two minutes, so a step calling a slow external service can be cut off mid-run. If the generated code talks to anything outside the application, read [Best practices](https://docs.kentico.com/x/automation_custom_steps_xp) for the timeout behavior and what to do instead. The same limit applies to a trigger's evaluation, and a trigger that runs out of time does not start its process.
+
+**Trigger identifiers** -- The identifier on the registration attribute, and the one on the trigger data class, are permanent. Changing either after marketers have built processes on the trigger breaks those processes. Renaming or removing a data property has the same effect, and the affected steps then receive no data. Check that the generated identifiers are ones you can live with, and that they carry a prefix unique to your project.
+
+**Trigger data** -- Trigger data is serialized and stored with the process. Keep it to identifiers the process can resolve later, and keep personal data such as names and e-mail addresses out of it.
+
+**Firing location** -- Confirm the dispatch call sits where the business event actually completes, and that it isn't inside a custom automation step. Firing is fire-and-forget from a bounded queue, so the call returns before the process starts and tells you nothing about whether it did.
 
 Other things to keep an eye on during review:
 

--- a/plugins/kentico-digital-experience/README.md
+++ b/plugins/kentico-digital-experience/README.md
@@ -2,13 +2,16 @@
 
 Extend the digital marketing features of Xperience by Kentico with custom components, written by your AI coding assistant.
 
-Marketers configure these features using the component types available to them. When they need behavior Xperience doesn't provide out of the box, such as posting to a chat channel or calling an internal service, a developer adds a custom component. This plugin hands that work to your coding assistant. You explain what the component does and which settings marketers control, and the agent writes the implementation together with the registration that makes it available in the admin UI.
+Marketers configure these features using the component types available to them. When they need behavior Xperience doesn't provide out of the box, such as posting to a chat channel, calling an internal service, or branching a process on data Xperience doesn't track, a developer adds a custom component. This plugin hands that work to your coding assistant. You explain what the component does and which settings marketers control, and the agent writes the implementation together with the registration that makes it available in the admin UI.
 
 ## Choose a skill
 
 | Skill | Use it to |
 |---|---|
 | `automation-action` | Implement and register a custom automation action, with optional marketer-configurable properties |
+| `automation-condition` | Implement and register a custom automation condition that branches a process, with optional marketer-configurable properties |
+
+The two skills cover the two kinds of custom step. An action *does* something for the contact that reaches it. A condition *decides* which of two paths that contact takes, and changes nothing.
 
 For the other kinds of automation customization, see the [customization overview](https://docs.kentico.com/x/automation_custom_xp).
 
@@ -21,6 +24,10 @@ For the other kinds of automation customization, see the [customization overview
 - An AI coding assistant with this plugin installed
 - The [Documentation MCP server](https://docs.kentico.com/x/mcp_server_xp), configured as described in [MCP setup](./MCP-setup.md)
 - A description of what the step does, and of any settings marketers need to change
+
+Additionally, `automation-condition` requires:
+
+- A description of the branch logic — what makes the condition true, what data it reads, and which path each outcome leads to
 
 ## Install
 
@@ -49,6 +56,28 @@ This sequence produces one working action, configurable by marketers. See the ot
 5. Build the project and restart the application, then open the **Automation** application and add your step to a process. Confirm the step appears under its display name and that its properties render in the configuration dialog.
 
 At this point the step is available to every marketer working in the Automation Builder, and it runs for each contact that reaches it.
+
+## Build your first condition
+
+This sequence produces one working condition that marketers can drop into a process to split it in two.
+
+1. Open the solution containing your Xperience web project in your AI coding assistant.
+
+2. Describe what makes the condition true and what data it reads. State which outcome belongs on which branch if it isn't obvious.
+
+   ```text
+   /automation-condition
+
+   Create a condition that is true when the contact has an active
+   subscription in our billing service. Marketers need to pick which
+   subscription tier counts as active.
+   ```
+
+3. Answer the design questions. The agent reads the current Xperience documentation and studies how your project is organized, then confirms the design before writing anything. Expect it to ask what should happen when the data it needs is missing.
+
+4. Review the generated code. The agent reports which files it created. Read [Review the output](#review-the-output).
+
+5. Build the project and restart the application, then open the **Automation** application and add your condition to a process. Confirm it appears under its display name, that its properties render in the configuration dialog, and that both the true and the false branch lead where you expect.
 
 ## Common tasks
 
@@ -83,6 +112,37 @@ Add a retry-count setting to the CrmSyncAction, editable by marketers,
 with a default of 3 and a maximum of 10.
 ```
 
+### Add an automation condition with no settings
+
+The agent skips the properties class entirely.
+
+```text
+/automation-condition
+
+Add a condition that is true when the contact's email address uses one
+of our internal domains. No marketer-facing settings.
+```
+
+### Branch on data produced by an earlier step
+
+Name the action that stores the data. The agent wires the condition to read the same process data type instead of fetching the value again.
+
+```text
+/automation-condition
+
+Add a condition that is true when the lead score stored by the
+LeadScoringAction is above a threshold the marketer sets.
+```
+
+### Add a property to an existing condition
+
+Describe the condition and the setting. The agent finds the existing classes and extends them rather than starting over.
+
+```text
+Add a country setting to the HasActiveSubscriptionCondition, editable by
+marketers as a dropdown, so the check can be limited to one market.
+```
+
 ## Write effective prompts
 
 Both of these prompts produce a working output. However, providing the agent with more context significantly reduces guesswork and increases output quality and standards adherence. Compare:
@@ -91,6 +151,8 @@ Both of these prompts produce a working output. However, providing the agent wit
 |---|---|
 | `Create an action that sends an email` | The agent works out the recipient, the source of the content, and which parts marketers control. Expect several rounds of questions. |
 | `Create an action that sends the contact a transactional email chosen by the marketer from a dropdown of published email templates` | The agent proposes a design right away and asks only about what you left open. |
+| `Create a condition that checks the contact's subscription` | The agent works out where the subscription data lives, what counts as a match, and which outcome belongs on the true branch. Expect several rounds of questions. |
+| `Create a condition that is true when the contact has an active subscription of a tier the marketer picks from a dropdown, read from our billing API` | The agent proposes a design right away and asks only about what you left open. |
 
 > [!TIP]
 > The same applies to every KentiCopilot skill. See [Write specific prompts](../../docs/Usage-Guide.md#write-specific-prompts) for the general guidance, including the habits that slow a session down.
@@ -102,6 +164,10 @@ Treat generated code the way you'd treat a pull request from someone new to the 
 **Form annotation namespace** -- The [form component](https://docs.kentico.com/x/8ASiCQ) attributes that build the configuration dialog need to come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces. An obsolete Form Builder namespace, `Kentico.Forms.Web.Mvc`, contains attributes with the same names. Check the `using` directives on the properties class.
 
 **Execution time limit** -- Actions are cancelled after two minutes, so a step calling a slow external service can be cut off mid-run. If the generated code talks to anything outside the application, read [Best practices](https://docs.kentico.com/x/automation_custom_steps_xp) for the timeout behavior and what to do instead.
+
+**Side effects in a condition** -- A condition evaluates and returns a result, nothing more. The same contact can be evaluated more than once, so anything the generated `Evaluate` method writes, sends, or stores happens repeatedly. Move that work into an action.
+
+**The false branch as the failure path** -- A condition that times out or throws resolves to `false`, which makes the false branch the path contacts take when something goes wrong, not only when the answer is genuinely no. Check that the branch is a safe place to land.
 
 Other things to keep an eye on during review:
 

--- a/plugins/kentico-digital-experience/README.md
+++ b/plugins/kentico-digital-experience/README.md
@@ -125,7 +125,7 @@ of our internal domains. No marketer-facing settings.
 
 ### Branch on data produced by an earlier step
 
-Name the action that stores the data. The agent wires the condition to read the same process data type instead of fetching the value again.
+Name the action that stores the data, so the agent wires the condition to the same process data type.
 
 ```text
 /automation-condition
@@ -163,11 +163,11 @@ Treat generated code the way you'd treat a pull request from someone new to the 
 
 **Form annotation namespace** -- The [form component](https://docs.kentico.com/x/8ASiCQ) attributes that build the configuration dialog need to come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces. An obsolete Form Builder namespace, `Kentico.Forms.Web.Mvc`, contains attributes with the same names. Check the `using` directives on the properties class.
 
-**Execution time limit** -- Actions are cancelled after two minutes, so a step calling a slow external service can be cut off mid-run. If the generated code talks to anything outside the application, read [Best practices](https://docs.kentico.com/x/automation_custom_steps_xp) for the timeout behavior and what to do instead.
+**Execution time limit** -- Custom steps are cancelled after two minutes, an action's `Execute` and a condition's `Evaluate` alike, so a step calling a slow external service can be cut off mid-run. If the generated code talks to anything outside the application, read [Best practices](https://docs.kentico.com/x/automation_custom_steps_xp) for the timeout behavior and what to do instead.
 
 **Side effects in a condition** -- A condition evaluates and returns a result, nothing more. The same contact can be evaluated more than once, so anything the generated `Evaluate` method writes, sends, or stores happens repeatedly. Move that work into an action.
 
-**The false branch as the failure path** -- A condition that times out or throws resolves to `false`, which makes the false branch the path contacts take when something goes wrong, not only when the answer is genuinely no. Check that the branch is a safe place to land.
+**Failures resolve to `false`** -- An unhandled exception and the two-minute timeout both make the condition return `false`, indistinguishable from a genuine no. Check that the generated `Evaluate` handles the failures it can, logs them, and returns a value it chose deliberately.
 
 Other things to keep an eye on during review:
 

--- a/plugins/kentico-digital-experience/README.md
+++ b/plugins/kentico-digital-experience/README.md
@@ -73,7 +73,7 @@ A trigger is two halves: the class marketers select in the Automation Builder, a
    controller after the payment is confirmed.
    ```
 
-2. Answer the design questions. Expect the agent to confirm which contact the trigger applies to and how the process should behave when the same contact purchases twice.
+2. Answer the design questions. Expect the agent to confirm which contact the trigger applies to and which data the process needs from the event.
 
 3. Review the generated code, including the dispatch call the agent added to your own class. Read [Review the output](#review-the-output).
 

--- a/plugins/kentico-digital-experience/skills/automation-action/SKILL.md
+++ b/plugins/kentico-digital-experience/skills/automation-action/SKILL.md
@@ -21,4 +21,4 @@ This skill points you to Kentico's automation-customization documentation. Use i
 ## Gotcha
 
 - Form-component and validation attributes come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces — never from `Kentico.Forms.Web.Mvc`, an obsolete Form Builder namespace with matching class names.
-- Prefer using `ILogger<T>` for logging instead of `EventLogService`.
+- Use `ILogger<T>` for logging. `EventLogService` is obsolete — don't use it.

--- a/plugins/kentico-digital-experience/skills/automation-condition/SKILL.md
+++ b/plugins/kentico-digital-experience/skills/automation-condition/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: "automation-condition"
+description: "Reference for implementing custom automation process conditions in Xperience by Kentico. Use whenever the user wants to branch an automation process on custom logic — a class that evaluates every contact reaching the step and sends it down the true or the false path, optionally configurable by marketers through properties."
+compatibility: "Requires Kentico Docs MCP"
+---
+
+This skill points you to Kentico's automation-customization documentation. Use it to implement a custom automation process condition.
+
+## Pieces of a custom condition
+
+- **Condition class** – inherits `AutomationCondition` (no configuration) or `AutomationCondition<TProperties>` (marketer-configurable); implements the logic in `Evaluate`, which returns `true` for the true branch and `false` for the false branch.
+- **Properties class** – implements `IAutomationConditionProperties`; public properties annotated with admin UI form components define the configuration dialog.
+- **Registration** – the `RegisterAutomationCondition` assembly attribute (identifier, display name, icon, description) makes the condition appear in the Automation Builder.
+- **Runtime context** – `AutomationProcessContext` gives access to the processed contact, the process, and trigger data.
+- **Process data** – `IAutomationProcessData` implementations carry typed data from earlier steps; a condition reads that data, it never writes it.
+
+## How to use
+
+- Read `references/docs.md` and fetch the docs pages listed there.
+
+## Gotcha
+
+- Keep `Evaluate` read-only and idempotent — a condition can be re-evaluated for the same contact, so side effects belong in an action.
+- Both an unhandled exception and the two-minute timeout resolve the condition to `false`, so design the false branch as the safe fallback path.
+- Form-component and validation attributes come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces — never from `Kentico.Forms.Web.Mvc`, an obsolete Form Builder namespace with matching class names.
+- Prefer using `ILogger<T>` for logging instead of `EventLogService`.

--- a/plugins/kentico-digital-experience/skills/automation-condition/SKILL.md
+++ b/plugins/kentico-digital-experience/skills/automation-condition/SKILL.md
@@ -21,6 +21,6 @@ This skill points you to Kentico's automation-customization documentation. Use i
 ## Gotcha
 
 - Keep `Evaluate` read-only and idempotent — a condition can be re-evaluated for the same contact, so side effects belong in an action.
-- Both an unhandled exception and the two-minute timeout resolve the condition to `false`, so design the false branch as the safe fallback path.
+- Both an unhandled exception and the two-minute timeout resolve the condition to `false`, indistinguishable from a genuine no — handle the failures you can inside `Evaluate`, log them, and return a deliberate result.
 - Form-component and validation attributes come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces — never from `Kentico.Forms.Web.Mvc`, an obsolete Form Builder namespace with matching class names.
-- Prefer using `ILogger<T>` for logging instead of `EventLogService`.
+- Use `ILogger<T>` for logging. `EventLogService` is obsolete — don't use it.

--- a/plugins/kentico-digital-experience/skills/automation-condition/references/docs.md
+++ b/plugins/kentico-digital-experience/skills/automation-condition/references/docs.md
@@ -1,0 +1,23 @@
+# Documentation links
+
+Fetch any link via the Kentico Docs MCP. Read only what the task needs.
+
+## Automation customization
+
+- **Custom automation steps**: <https://docs.kentico.com/documentation/developers-and-admins/digital-marketing-setup/automation-customization/automation-custom-steps>
+  - When to read: always, first. The authoritative reference — base classes, full examples, condition properties, registration, branching, runtime context (processed contact, trigger data, process data), and best practices (read-only evaluation, timeouts, error handling, data protection, versioning, property guidelines, dependency injection).
+- **Automation customization overview**: <https://docs.kentico.com/documentation/developers-and-admins/digital-marketing-setup/automation-customization>
+  - When to read: to see what kinds of custom automation components exist and where conditions fit.
+- **Automation overview**: <https://docs.kentico.com/documentation/business-users/digital-marketing/automation>
+  - When to read: to understand the marketer's mental model — triggers, step types, branching, contact mapping — before designing a condition.
+
+## Admin UI form components (for the properties class)
+
+- **Form components reference**: <https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/reference-admin-ui-form-components>
+  - When to read: when picking editing components for condition properties.
+- **Validation rules**: <https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/ui-form-component-validation-rules.html>
+  - When to read: when constraining property values declaratively or defining a custom rule.
+- **Visibility conditions**: <https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/ui-form-component-visibility-conditions.html>
+  - When to read: when a property should show or hide based on another property's value.
+- **Configure editing component state**: <https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/editing-components/configure-editing-component-state>
+  - When to read: when cross-field dependencies need a component configurator — e.g. a dropdown whose options depend on another property.

--- a/plugins/kentico-digital-experience/skills/automation-trigger/SKILL.md
+++ b/plugins/kentico-digital-experience/skills/automation-trigger/SKILL.md
@@ -11,8 +11,7 @@ This skill points you to Kentico's automation-customization documentation. Use i
 - **Trigger class** – inherits `AutomationTrigger` (no data), `AutomationTrigger<TData>`, or `AutomationTrigger<TData, TProperties>` (marketer-configurable); overrides `Evaluate` to decide whether the process starts.
 - **Trigger data** – implements `IAutomationTriggerData` with a stable `Identifier`; JSON-serialized with the process state and read by later steps through `AutomationProcessContext.GetTriggerData<T>()`.
 - **Properties class** – implements `IAutomationTriggerProperties`; public properties annotated with admin UI form components define the configuration dialog marketers see when they pick the trigger.
-- **Registration** – the `RegisterAutomationTrigger<TTrigger>` assembly attribute (identifier, display name, icon, description) makes the trigger selectable in the Automation Builder.
-- **Dispatch** – `IAutomationTriggerDispatcher.FireTrigger<TTrigger>` with an `AutomationTriggerDispatch` built from a `ContactInfo` and, for data-carrying triggers, the trigger data.
+- **Registration** – the generic `RegisterAutomationTrigger<TTrigger>` assembly attribute makes the trigger selectable in the Automation Builder.
 
 ## How to use
 
@@ -25,5 +24,6 @@ This skill points you to Kentico's automation-customization documentation. Use i
 - Trigger classes must be stateless; one instance serves every evaluation, which is cancelled after two minutes.
 - Keep trigger data small and free of personal data — carry identifiers, not names, e-mail addresses, or keys.
 - Don't fire triggers from inside a custom automation step — log a custom activity and let the built-in step do it.
+- Every trigger type lives in `CMS.Automation`. Only the form-component attributes on the properties class come from elsewhere.
 - Form-component and validation attributes come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces — never from `Kentico.Forms.Web.Mvc`, an obsolete Form Builder namespace with matching class names.
 - Prefer using `ILogger<T>` for logging instead of `EventLogService`.

--- a/plugins/kentico-digital-experience/skills/automation-trigger/SKILL.md
+++ b/plugins/kentico-digital-experience/skills/automation-trigger/SKILL.md
@@ -21,9 +21,9 @@ This skill points you to Kentico's automation-customization documentation. Use i
 ## Gotcha
 
 - Never change a trigger's `identifier` or a trigger data class's `Identifier` after deployment. Adding optional data properties is safe; removing or renaming them breaks deserialization, and steps then receive `null`. Version by registering a new trigger alongside the old one.
-- Trigger classes must be stateless; one instance serves every evaluation, which is cancelled after two minutes.
+- Trigger classes must be stateless; one instance serves every evaluation.
 - Keep trigger data small and free of personal data — carry identifiers, not names, e-mail addresses, or keys.
 - Don't fire triggers from inside a custom automation step — log a custom activity and let the built-in step do it.
 - Every trigger type lives in `CMS.Automation`. Only the form-component attributes on the properties class come from elsewhere.
 - Form-component and validation attributes come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces — never from `Kentico.Forms.Web.Mvc`, an obsolete Form Builder namespace with matching class names.
-- Prefer using `ILogger<T>` for logging instead of `EventLogService`.
+- Use `ILogger<T>` for logging. `EventLogService` is obsolete — don't use it.

--- a/plugins/kentico-digital-experience/skills/automation-trigger/SKILL.md
+++ b/plugins/kentico-digital-experience/skills/automation-trigger/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: "automation-trigger"
+description: "Reference for implementing custom automation triggers in Xperience by Kentico. Use whenever the user wants an automation process to start from application code — a purchase, an incoming webhook, an event handler, or a scheduled task — optionally carrying typed data into the process and configurable by marketers through properties."
+compatibility: "Requires Kentico Docs MCP"
+---
+
+This skill points you to Kentico's automation-customization documentation. Use it to implement a custom automation trigger and fire it from the project's code.
+
+## Pieces of a custom trigger
+
+- **Trigger class** – inherits `AutomationTrigger` (no data), `AutomationTrigger<TData>`, or `AutomationTrigger<TData, TProperties>` (marketer-configurable); overrides `Evaluate` to decide whether the process starts.
+- **Trigger data** – implements `IAutomationTriggerData` with a stable `Identifier`; JSON-serialized with the process state and read by later steps through `AutomationProcessContext.GetTriggerData<T>()`.
+- **Properties class** – implements `IAutomationTriggerProperties`; public properties annotated with admin UI form components define the configuration dialog marketers see when they pick the trigger.
+- **Registration** – the `RegisterAutomationTrigger<TTrigger>` assembly attribute (identifier, display name, icon, description) makes the trigger selectable in the Automation Builder.
+- **Dispatch** – `IAutomationTriggerDispatcher.FireTrigger<TTrigger>` with an `AutomationTriggerDispatch` built from a `ContactInfo` and, for data-carrying triggers, the trigger data.
+
+## How to use
+
+- Read `references/docs.md` and fetch the docs pages listed there.
+- A trigger class alone does nothing. Confirm with the user where the trigger fires — event handler, controller, webhook endpoint, or scheduled task — and wire the `FireTrigger` call into that code path.
+
+## Gotcha
+
+- Triggers operate on contacts — the object dispatched must be a `ContactInfo`.
+- Trigger classes must be stateless; one instance serves every evaluation. `Evaluate` is cancelled after two minutes, and the process then does not start.
+- Never change a trigger's `identifier` or a trigger data class's `Identifier` after deployment. Adding optional data properties is safe; removing or renaming them breaks deserialization, and steps then receive `null`. Version by registering a new trigger alongside the old one.
+- Keep trigger data small and free of personal data — carry identifiers, not names, e-mail addresses, or keys. `DateTime` values round-trip as UTC.
+- `FireTrigger` enqueues and returns immediately. The queue is bounded (`CMSAutomationTriggerQueueCapacity`) and drops triggers with a warning when saturated; it is a silent no-op when no process uses the trigger, and throws `InvalidOperationException` for an unregistered trigger or data of the wrong type.
+- Don't fire triggers from inside a custom automation step — log a custom activity and let the built-in step do it.
+- Form-component and validation attributes come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces — never from `Kentico.Forms.Web.Mvc`, an obsolete Form Builder namespace with matching class names.
+- Prefer using `ILogger<T>` for logging instead of `EventLogService`.

--- a/plugins/kentico-digital-experience/skills/automation-trigger/SKILL.md
+++ b/plugins/kentico-digital-experience/skills/automation-trigger/SKILL.md
@@ -21,11 +21,9 @@ This skill points you to Kentico's automation-customization documentation. Use i
 
 ## Gotcha
 
-- Triggers operate on contacts — the object dispatched must be a `ContactInfo`.
-- Trigger classes must be stateless; one instance serves every evaluation. `Evaluate` is cancelled after two minutes, and the process then does not start.
 - Never change a trigger's `identifier` or a trigger data class's `Identifier` after deployment. Adding optional data properties is safe; removing or renaming them breaks deserialization, and steps then receive `null`. Version by registering a new trigger alongside the old one.
-- Keep trigger data small and free of personal data — carry identifiers, not names, e-mail addresses, or keys. `DateTime` values round-trip as UTC.
-- `FireTrigger` enqueues and returns immediately. The queue is bounded (`CMSAutomationTriggerQueueCapacity`) and drops triggers with a warning when saturated; it is a silent no-op when no process uses the trigger, and throws `InvalidOperationException` for an unregistered trigger or data of the wrong type.
+- Trigger classes must be stateless; one instance serves every evaluation, which is cancelled after two minutes.
+- Keep trigger data small and free of personal data — carry identifiers, not names, e-mail addresses, or keys.
 - Don't fire triggers from inside a custom automation step — log a custom activity and let the built-in step do it.
 - Form-component and validation attributes come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces — never from `Kentico.Forms.Web.Mvc`, an obsolete Form Builder namespace with matching class names.
 - Prefer using `ILogger<T>` for logging instead of `EventLogService`.

--- a/plugins/kentico-digital-experience/skills/automation-trigger/references/docs.md
+++ b/plugins/kentico-digital-experience/skills/automation-trigger/references/docs.md
@@ -1,0 +1,34 @@
+# Documentation links
+
+Fetch any link via the Kentico Docs MCP. Read only what the task needs.
+
+## Automation customization
+
+- **Custom automation triggers**: <https://docs.kentico.com/documentation/developers-and-admins/digital-marketing-setup/automation-customization/automation-custom-triggers>
+  - When to read: always, first. The authoritative reference — base classes, `Evaluate`, trigger data, trigger properties, registration, dispatching from code, time-based triggers, and best practices (statelessness, timeouts, data guidelines, versioning).
+- **Custom automation steps**: <https://docs.kentico.com/documentation/developers-and-admins/digital-marketing-setup/automation-customization/automation-custom-steps>
+  - When to read: when a step inside the process has to consume the trigger data, or when the task turns out to need a custom action rather than a trigger.
+- **Automation customization overview**: <https://docs.kentico.com/documentation/developers-and-admins/digital-marketing-setup/automation-customization>
+  - When to read: to see what kinds of custom automation components exist and where triggers fit.
+- **Automation overview**: <https://docs.kentico.com/documentation/business-users/digital-marketing/automation>
+  - When to read: to understand the marketer's mental model — how a trigger starts a process, recurrence settings, contact mapping — before designing a trigger.
+
+## Firing the trigger
+
+- **Contacts API examples**: <https://docs.kentico.com/api/digital-marketing/contacts>
+  - When to read: to obtain the `ContactInfo` to dispatch against — the current request's contact or one retrieved by query.
+- **Handle global events**: <https://docs.kentico.com/documentation/developers-and-admins/customization/handle-global-events>
+  - When to read: when the trigger fires from an object or content event rather than from application code you control.
+- **Scheduled tasks**: <https://docs.kentico.com/documentation/developers-and-admins/customization/scheduled-tasks>
+  - When to read: for time-based triggers — a task loads the matching contacts and fires the trigger for each. Docs recommend running such a task at most once per day.
+
+## Admin UI form components (for the properties class)
+
+- **Form components reference**: <https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/reference-admin-ui-form-components>
+  - When to read: when picking editing components for trigger properties.
+- **Validation rules**: <https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/ui-form-component-validation-rules.html>
+  - When to read: when constraining property values declaratively or defining a custom rule.
+- **Visibility conditions**: <https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/ui-form-component-visibility-conditions.html>
+  - When to read: when a property should show or hide based on another property's value.
+- **Configure editing component state**: <https://docs.kentico.com/documentation/developers-and-admins/customization/extend-the-administration-interface/ui-form-components/editing-components/configure-editing-component-state>
+  - When to read: when cross-field dependencies need a component configurator — e.g. a dropdown whose options depend on another property.


### PR DESCRIPTION
<!--
Thanks for contributing to KentiCopilot! Before opening this PR, read AGENTS.md
at the repository root for the repo layout and the conventions for plugins and skills.
Fill in the sections that apply and delete the ones that don't.
-->

## Summary

This PR adds two new digital experience skills that complete coverage of what is possible with customisations in XbyK's automation.

## Following the conventions

- [x] The resource targets **Kentico Xperience developers** and is meant to be invoked by an AI assistant (not aimed at marketing, sales, or support).
- [x] The resource does **not** duplicate the Kentico documentation — it links the relevant docs pages and adds context instead.
- [x] A new resource is genuinely needed — the same result can't be achieved with an existing resource, a docs link, or a well-written prompt.
- [x] The resource avoids features or fields specific to a single AI tool, so it works across different AI assistants.
- [x] Plugin and marketplace versions are bumped per the [versioning rules](../docs/Contributing-Setup.md) — any plugin change bumps the marketplace version at least by a patch, and both marketplace files match.
