### PR TITLE
Docs/automation skills documentation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Agent plugins that teach AI coding assistants how to build, migrate, and maintain Xperience by Kentico projects",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "kentico-digital-experience",
       "source": "./plugins/kentico-digital-experience",
       "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions and conditions that add custom step types to the Automation Builder and Automation triggers that start processes from application code",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "Kentico"
       },

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "xperience-by-kentico-kenticopilot",
   "metadata": {
     "description": "Agent plugins that teach AI coding assistants how to build, migrate, and maintain Xperience by Kentico projects",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "pluginRoot": "./plugins"
   },
   "owner": {
@@ -14,7 +14,7 @@
       "name": "kentico-digital-experience",
       "source": "./kentico-digital-experience",
       "description": "Extend Xperience digital experience workflows with custom components, such as Automation actions and conditions that add custom step types to the Automation Builder and Automation triggers that start processes from application code",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "Kentico"
       },

--- a/docs/Contributing-Setup.md
+++ b/docs/Contributing-Setup.md
@@ -18,6 +18,7 @@ Keep each document focused on one reader need:
 |---|---|
 | Root `README.md` | Explain the marketplace, help users choose a plugin, and provide a short installation path |
 | Plugin `README.md` | Explain when to use the plugin, how its skills fit together, requirements, examples, and how to review what it produces |
+| Plugin `MCP-setup.md` | Explain what MCP server the plugin requires, and provide a `.mcp.json` snippet to show how to configure them |
 | `SKILL.md` | Instruct the agent how to execute one task; do not use it as the primary user guide |
 | Skill `references/` | Give the agent focused material it loads only when needed |
 

--- a/docs/Usage-Guide.md
+++ b/docs/Usage-Guide.md
@@ -100,7 +100,7 @@ Use this alternative only when your assistant cannot install from a marketplace.
 
 2. Follow your assistant's plugin or skill-loading conventions for the selected folder under `plugins/`.
 
-Do not copy every plugin into a project by default. Keeping only the relevant plugin reduces noise and prevents unrelated skills from burdening agent context.
+Do not copy every plugin into a project by default. Keeping only the relevant plugins reduces noise and prevents unrelated skills from burdening agent context.
 
 ## Invoke a skill
 

--- a/plugins/kentico-digital-experience/README.md
+++ b/plugins/kentico-digital-experience/README.md
@@ -170,6 +170,7 @@ Describe the condition and the setting. The agent finds the existing classes and
 ```text
 Add a country setting to the HasActiveSubscriptionCondition, editable by
 marketers as a dropdown, so the check can be limited to one market.
+```
 
 ### Pass data from a trigger into the process
 

--- a/plugins/kentico-digital-experience/README.md
+++ b/plugins/kentico-digital-experience/README.md
@@ -2,7 +2,7 @@
 
 Extend the digital marketing features of Xperience by Kentico with custom components, written by your AI coding assistant.
 
-Marketers configure these features using the component types available to them. When they need behavior Xperience doesn't provide out of the box, a developer adds a custom component — a step inside a process or the trigger that starts it. For example, such custom behavior can include posting to a chat channel, calling an internal service, starting a process the moment an order is paid, or branching a process on data Xperience doesn't track. This plugin hands over development of custom automation components to your coding assistant. You explain what the component needs to do and which settings marketers control, and the agent writes the implementation together with the registration that makes it available in the admin UI.
+Marketers configure these features using the component types available to them. When they need behavior Xperience doesn't provide out of the box, a developer adds a custom component – a step inside a process or the trigger that starts it. For example, such custom behavior can include posting to a chat channel, calling an internal service, starting a process the moment an order is paid, or branching a process on data Xperience doesn't track. This plugin hands over development of custom automation components to your coding assistant. You explain what the component needs to do and which settings marketers control, and the agent writes the implementation together with the registration that makes it available in the admin UI.
 
 ## Choose a skill
 
@@ -28,12 +28,12 @@ To learn about the available types of automation customization, see the [customi
 
 Additionally, `automation-trigger` requires:
 
-- The code path that should start the process — an event handler, a controller or webhook endpoint, or a scheduled task
+- The code path that should start the process – an event handler, a controller or webhook endpoint, or a scheduled task
 - The contact the process applies to, and any data the trigger passes into it
 
 Additionally, `automation-condition` requires:
 
-- A description of the branch logic — what makes the condition true, what data it reads, and which path each outcome leads to
+- A description of the branch logic – what makes the condition true, what data it reads, and which path each outcome leads to
 
 ## Install
 
@@ -106,7 +106,7 @@ A trigger is two halves: the class marketers select in the Automation Builder, a
 
 4. Build the project and restart the application, then open the **Automation** application and create a process that starts from your trigger.
 
-5. Exercise the code path — place an order, raise the event, or run the scheduled task — and confirm the process starts for the expected contact.
+5. Exercise the code path – place an order, raise the event, or run the scheduled task – and confirm the process starts for the expected contact.
 
 ## Common tasks
 

--- a/plugins/kentico-digital-experience/README.md
+++ b/plugins/kentico-digital-experience/README.md
@@ -2,7 +2,7 @@
 
 Extend the digital marketing features of Xperience by Kentico with custom components, written by your AI coding assistant.
 
-Marketers configure these features using the component types available to them. When they need behavior Xperience doesn't provide out of the box, such as posting to a chat channel, calling an internal service, starting a process the moment an order is paid, or branching a process on data Xperience doesn't track, a developer adds a custom component — a step inside a process, or the trigger that starts it. This plugin hands that work to your coding assistant. You explain what the component does and which settings marketers control, and the agent writes the implementation together with the registration that makes it available in the admin UI.
+Marketers configure these features using the component types available to them. When they need behavior Xperience doesn't provide out of the box, a developer adds a custom component — a step inside a process or the trigger that starts it. For example, such custom behavior can include posting to a chat channel, calling an internal service, starting a process the moment an order is paid, or branching a process on data Xperience doesn't track. This plugin hands over development of custom automation components to your coding assistant. You explain what the component needs to do and which settings marketers control, and the agent writes the implementation together with the registration that makes it available in the admin UI.
 
 ## Choose a skill
 
@@ -10,11 +10,11 @@ Marketers configure these features using the component types available to them. 
 |---|---|
 | `automation-action` | Implement and register a custom automation action, with optional marketer-configurable properties |
 | `automation-condition` | Implement and register a custom automation condition that branches a process, with optional marketer-configurable properties |
-| `automation-trigger` | Implement and register a custom automation trigger, and fire it from your application code |
+| `automation-trigger` | Implement and register a custom automation trigger, with optional marketer-configurable properties, and fire the trigger from your application code |
 
 The three skills meet in one process: A trigger decides when the process starts and what data it carries. An action *does* something for a contact that reaches it. A condition *decides* which of two paths that contact takes, and changes nothing.
 
-For the other kinds of automation customization, see the [customization overview](https://docs.kentico.com/x/automation_custom_xp).
+To learn about the available types of automation customization, see the [customization overview](https://docs.kentico.com/x/automation_custom_xp).
 
 > [!TIP]
 > New to agent skills? Agents activate skills as necessary based on the assigned task. Alternatively, you can use slash commands and other methods depending on your assistant. For what that means in practice, read [Invoke a skill](../../docs/Usage-Guide.md#invoke-a-skill).
@@ -213,19 +213,19 @@ Both of these prompts produce a working output. However, providing the agent wit
 
 Treat generated code the way you'd treat a pull request from someone new to the project. The following things are worth reviewing:
 
-**Form annotation namespace** -- The [form component](https://docs.kentico.com/x/8ASiCQ) attributes that build the configuration dialog need to come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces. An obsolete Form Builder namespace, `Kentico.Forms.Web.Mvc`, contains attributes with the same names. Check the `using` directives on the properties class.
+**Form annotation namespace** – The [form component](https://docs.kentico.com/x/8ASiCQ) attributes that build the configuration dialog need to come from the `Kentico.Xperience.Admin.*.FormAnnotations` namespaces. An obsolete Form Builder namespace, `Kentico.Forms.Web.Mvc`, contains attributes with the same names. Check the `using` directives on the properties class.
 
-**Execution time limit** -- Custom steps are cancelled after two minutes, an action's `Execute` and a condition's `Evaluate` alike, so a step calling a slow external service can be cut off mid-run. If the generated code talks to anything outside the application, read [Best practices](https://docs.kentico.com/x/automation_custom_steps_xp) for the timeout behavior and what to do instead. The same limit applies to a trigger's evaluation, and a trigger that runs out of time does not start its process.
+**Execution time limit** – Custom steps are cancelled after two minutes, an action's `Execute` and a condition's `Evaluate` alike, so a step calling a slow external service can be cut off mid-run. If the generated code talks to anything outside the application, read [Best practices](https://docs.kentico.com/x/automation_custom_steps_xp) for the timeout behavior and what to do instead. The same limit applies to a trigger's evaluation, and a trigger that runs out of time does not start its process.
 
-**Side effects in a condition** -- A condition evaluates and returns a result, nothing more. The same contact can be evaluated more than once, so anything the generated `Evaluate` method writes, sends, or stores happens repeatedly. Move that work into an action.
+**Side effects in a condition** – A condition evaluates and returns a result, nothing more. The same contact can be evaluated more than once, so anything the generated `Evaluate` method writes, sends, or stores happens repeatedly. Move that work into an action.
 
-**Failures resolve to `false`** -- An unhandled exception and the two-minute timeout both make the condition return `false`, indistinguishable from a genuine no. Check that the generated `Evaluate` handles the failures it can, logs them, and returns a value it chose deliberately.
+**Failures resolve to `false` for conditions** – An unhandled exception and the two-minute timeout both make the condition return `false`, indistinguishable from a genuine no. Check that the generated `Evaluate` handles the failures it can, logs them, and returns a value it chose deliberately.
 
-**Trigger identifiers** -- The identifier on the registration attribute, and the one on the trigger data class, are permanent. Changing either after marketers have built processes on the trigger breaks those processes. Renaming or removing a data property has the same effect, and the affected steps then receive no data. Check that the generated identifiers are ones you can live with, and that they carry a prefix unique to your project.
+**Trigger identifiers** – The identifier on the registration attribute, and the one on the trigger data class, are permanent. Changing either after marketers have built processes on the trigger breaks those processes. Renaming or removing a data property has the same effect, and the affected steps then receive no data. Check that the generated identifiers are ones you can live with, and that they carry a prefix unique to your project.
 
-**Trigger data** -- Trigger data is serialized and stored with the process. Keep it to identifiers the process can resolve later, and keep personal data such as names and e-mail addresses out of it.
+**Trigger and action data** – Trigger and action data is serialized and stored with the process. Store identifiers the process can resolve later, and keep personal data such as names and email addresses out of it.
 
-**Firing location** -- Confirm the dispatch call sits where the business event actually completes, and that it isn't inside a custom automation step. Firing is fire-and-forget from a bounded queue, so the call returns before the process starts and tells you nothing about whether it did.
+**Firing location** – Confirm the dispatch call sits where the business event actually completes, and that it isn't inside a custom automation step. Firing is fire-and-forget from a bounded queue, so the call returns before the process starts and tells you nothing about whether it did.
 
 Other things to keep an eye on during review:
 

--- a/plugins/kentico-digital-experience/skills/automation-trigger/SKILL.md
+++ b/plugins/kentico-digital-experience/skills/automation-trigger/SKILL.md
@@ -20,7 +20,6 @@ This skill points you to Kentico's automation-customization documentation. Use i
 
 ## Gotcha
 
-- Never change a trigger's `identifier` or a trigger data class's `Identifier` after deployment. Adding optional data properties is safe; removing or renaming them breaks deserialization, and steps then receive `null`. Version by registering a new trigger alongside the old one.
 - Trigger classes must be stateless; one instance serves every evaluation.
 - Keep trigger data small and free of personal data — carry identifiers, not names, e-mail addresses, or keys.
 - Don't fire triggers from inside a custom automation step — log a custom activity and let the built-in step do it.

--- a/plugins/kentico-kx13-migration/README.md
+++ b/plugins/kentico-kx13-migration/README.md
@@ -44,14 +44,14 @@ The stages run in the order below, and each one has its own skill group:
 |---|---|---|---|
 | 1 | [Plan and audit the source content model](#content-model-audit) | `migrate-content-audit`, reading your KX13 source database | [Plan your upgrade approach](https://docs.kentico.com/x/migrate_from_kx13_overview_guides#plan-your-upgrade-approach) |
 | 2 | [Set up your environment](#set-up-your-environment) | No skill. You do this stage by hand | [Set up your environment](https://docs.kentico.com/x/setup_your_environment_guides) |
-| 3 | [Migrate data and binary files](#content-migration) | The content-migration skills, as a plan, configure, codegen, run, and evaluate loop around the Migration Tool | [Migrate data and binary files](https://docs.kentico.com/x/migrate_data_and_binary_files_guides) |
+| 3 | [Migrate data and binary files](#content-migration) | The content migration skills, as a plan, configure, codegen, run, and evaluate loop around the Migration Tool | [Migrate data and binary files](https://docs.kentico.com/x/migrate_data_and_binary_files_guides) |
 | 4 | [Adjust global code](#codebase-migration) | `migrate-code-global` | [Adjust global code on the backend](https://docs.kentico.com/x/adjust_global_code_guides) |
 | 5 | [Display an upgraded page](#codebase-migration) | The page, component, widget, and visual migration skills | [Display an upgraded page](https://docs.kentico.com/x/display_an_upgraded_page_guides) |
 
 [Prep for the upgrade and transfer data](https://docs.kentico.com/x/prep_for_migration_and_transfer_data_guides) covers stages 2 and 3 together, and [Adjust your code and adapt your project](https://docs.kentico.com/x/migrate_your_code_guides) is the conceptual companion to stages 4 and 5.
 
 > [!NOTE]
-> The content-migration stage needs to complete before the codebase stage starts. The codebase-migration skills generate C# entity classes from the migrated XbyK database with `--kxp-codegen`, and the content types need to exist in the target before that command runs.
+> The content migration stage needs to complete before the codebase stage starts. The codebase migration skills generate C# entity classes from the migrated XbyK database with `--kxp-codegen`, and the content types need to exist in the target before that command runs.
 
 ---
 
@@ -59,9 +59,9 @@ The stages run in the order below, and each one has its own skill group:
 
 1. Hotfix KX13 to **Refresh 5 (13.0.64)** or newer. The Migration Tool depends on fields added in this refresh.
 2. Pick an XbyK version compatible with a Kentico Migration Tool release per the [Library Version Matrix](https://github.com/Kentico/xperience-by-kentico-kentico-migration-tool/blob/master/README.md#library-version-matrix), and install it using the [`kentico-xperience-mvc` project template](https://docs.kentico.com/x/DQKQC).
-3. Clone the [Kentico Migration Tool](https://github.com/Kentico/xperience-by-kentico-kentico-migration-tool). The `Migration.Tool.Extensions` project is where the content-migration code-generation skills write `IClassMapping`, `IFieldMigration`, `IWidgetMigration`, and `ContentItemDirectorBase` implementations. See the [Extensions README](https://github.com/Kentico/xperience-by-kentico-kentico-migration-tool/blob/master/Migration.Tool.Extensions/README.md) for the project layout.
+3. Clone the [Kentico Migration Tool](https://github.com/Kentico/xperience-by-kentico-kentico-migration-tool). The `Migration.Tool.Extensions` project is where the content migration code generation skills write `IClassMapping`, `IFieldMigration`, `IWidgetMigration`, and `ContentItemDirectorBase` implementations. See the [Extensions README](https://github.com/Kentico/xperience-by-kentico-kentico-migration-tool/blob/master/Migration.Tool.Extensions/README.md) for the project layout.
 4. Source instance: rejoin a separated contact-management database if applicable. The source must be running during migration.
-5. Target instance: must **not** be running during migration, and must be empty (or carry only data from prior migration runs). For re-runs, delete contacts, activities, consent agreements, form submissions, and custom-module-class data first per the [target-instance setup](https://github.com/Kentico/xperience-by-kentico-kentico-migration-tool/blob/master/Migration.Tool.CLI/README.md#set-up-the-target-instance).
+5. Target instance: must **not** be running during migration, and must be empty (or carry only data from prior migration runs). For re-runs, delete contacts, activities, consent agreements, form submissions, and custom module class data first per the [target-instance setup](https://github.com/Kentico/xperience-by-kentico-kentico-migration-tool/blob/master/Migration.Tool.CLI/README.md#set-up-the-target-instance).
 
 Place the source, target, Migration Tool, and audit output in one workspace:
 
@@ -85,7 +85,7 @@ Place the source, target, Migration Tool, and audit output in one workspace:
 
 `migrate-content-audit` runs the bundled .NET auditor against the KX13 database and exports the source model as JSON plus a Markdown report. Use its output as the input to `migrate-content-plan`. The auditor captures the content model and the references between its parts, and it migrates nothing.
 
-The export covers the content tree, page types, custom tables, custom modules, forms, Page Builder components, page relationships, and content references. `migrate-content-plan` interprets that snapshot to decide content-type strategy and Migration Tool configuration.
+The export covers the content tree, page types, custom tables, custom modules, forms, Page Builder components, page relationships, and content references. `migrate-content-plan` interprets that snapshot to decide content type strategy and Migration Tool configuration.
 
 The auditor does **not** capture KX13 categories, commerce data, or marketing entities, and contacts are excluded as well. See [Scope and limitations](#scope-and-limitations). Review those areas manually using [Plan your strategy for migrating features](https://docs.kentico.com/x/plan_your_strategy_for_migrating_features_guides) and the [commerce features overview](https://docs.kentico.com/x/xperience_upgrade_commerce_features_overview_guides) guides.
 
@@ -103,7 +103,7 @@ Once the setup is complete, continue by describing the audit requirements:
 Audit the DancingGoatMvc site as the starting point for migrating it to Xperience by Kentico. Export the full content model into ./audit-results/
 ```
 
-Narrower requests work too, such as auditing page types and forms for classes matching `DancingGoat.*`, or exporting only the content tree below a given path. By default, the audit exports the full content model and the report.
+More specific requests work too, such as auditing page types and forms for classes matching `DancingGoat.*`, or exporting only the content tree below a given path. By default, the audit exports the full content model and the report.
 
 ### Auditor prerequisites
 
@@ -144,11 +144,11 @@ dotnet run --project src/KX13.ContentAuditor.CLI -- --help
 
 ## Content migration
 
-These skills drive the [Kentico Migration Tool](https://github.com/Kentico/xperience-by-kentico-kentico-migration-tool): they turn the audit into a plan, generate configuration and extensions, run the migration, and evaluate the result. They expect the [workspace layout](#set-up-your-environment) from the environment stage.
+These skills drive the [Kentico Migration Tool](https://github.com/Kentico/xperience-by-kentico-kentico-migration-tool): they turn the audit into a plan, generate configuration and extensions, run the migration, and evaluate the result. They expect the [workspace layout](#set-up-your-environment) from the environment setup stage.
 
 The skills run in four phases. The configure, generate, run, and evaluate phases form an iterative loop.
 
-### Content-migration skill sequence
+### Content migration skill sequence
 
 | Phase | Skill | Outcome | Guides |
 |---|---|---|---|
@@ -166,7 +166,7 @@ The skills run in four phases. The configure, generate, run, and evaluate phases
 
 Run all four generate-phase skills. Each reads `migration-detail.md`, skips when its extension type is unnecessary, and builds the extensions project after writing code.
 
-`migrate-content-plan` turns the audit output into a Migration Overview and a Migration Detail document. The Migration Detail is the primary input every later skill consumes. The [Speed up remodeling with AI](https://docs.kentico.com/x/speed_up_remodeling_with_ai_guides) guide describes the AI patterns this skill operationalizes for content-type and field-mapping decisions. Concretely, the plan derives:
+`migrate-content-plan` turns the audit output into a Migration Overview and a Migration Detail document. The Migration Detail is the primary input every later skill consumes. The [Speed up remodeling with AI](https://docs.kentico.com/x/speed_up_remodeling_with_ai_guides) guide describes the AI patterns this skill operationalizes for content type and field-mapping decisions. Specifically, the plan derives:
 
 - Which page types to convert to reusable content types → [`ConvertClassesToContentHub`](https://github.com/Kentico/xperience-by-kentico-kentico-migration-tool/blob/master/Migration.Tool.CLI/README.md#convert-pages-or-custom-tables-to-content-hub).
 - Which fields to extract into [reusable field schemas](https://docs.kentico.com/x/D4_OD) → `ReusableSchemaBuilder` / `CreateReusableFieldSchemaForClasses`.
@@ -208,7 +208,7 @@ Evaluate the result against ./migration-detail.md and identify which
 skill or manual step should address each finding.
 ```
 
-### Content-migration rules
+### Content migration rules
 
 - Audit before planning and treat `migration-detail.md` as the source of truth.
 - Review all generated configuration and C# extensions before running the Migration Tool.
@@ -239,7 +239,7 @@ Start the KX13 application or provide an accessible URL. Leave the XbyK applicat
 
 - `migrate-code-global` – sets up the XbyK project foundation (a `{ProjectName}.Entities` class library with the `CMS.AssemblyDiscoverableAttribute` assembly attribute), generates entity classes via [`--kxp-codegen`](https://docs.kentico.com/x/5IbWCQ), copies global code (localization, shared views, styles and scripts, identifiers, service registrations), and configures `Program.cs` for Page Builder and content-tree-based routing.
 - `migrate-code-component` – migrates reusable components (header, footer, navigation) using the content-retrieval API conversion described for `migrate-code-page`.
-- `migrate-code-page-widgets` – migrates Page Builder widgets and sections used by a page. This is the codebase counterpart to the content-migration `migrate-content-widgets` skill, converting KX13 `[EditingComponent(...)]` attributes to the new XbyK [form-component attributes](https://docs.kentico.com/x/8ASiCQ) (`[TextInputComponent]`, `[ContentItemSelectorComponent]`, etc.) per [Transform widget properties](https://docs.kentico.com/x/transform_widget_properties_guides).
+- `migrate-code-page-widgets` – migrates Page Builder widgets and sections used by a page. This is the codebase counterpart to the content migration `migrate-content-widgets` skill, converting KX13 `[EditingComponent(...)]` attributes to the new XbyK [form-component attributes](https://docs.kentico.com/x/8ASiCQ) (`[TextInputComponent]`, `[ContentItemSelectorComponent]`, etc.) per [Transform widget properties](https://docs.kentico.com/x/transform_widget_properties_guides).
 - `migrate-code-page` – migrates a page's controller, views, repositories, and dependencies. Converts KX13 `IPageRetriever` / `DocumentHelper` / `TreeProvider` / `DocumentQuery` patterns to XbyK's [`IContentRetriever`](https://docs.kentico.com/x/content_retriever_api_xp) / [`ContentItemQueryBuilder`](https://docs.kentico.com/x/WhT_Cw) per [Upgrade your content retrieval code](https://docs.kentico.com/x/upgrade_content_retrieval_code_guides).
 - `migrate-code-page-visual` – uses Playwright to align the migrated page visually with the KX13 original.
 
@@ -284,7 +284,7 @@ legacyPageUrl: https://localhost:5001/en-us/home
 newPageUrl: http://localhost:60444/en-us/home
 ```
 
-### Codebase-migration rules
+### Codebase migration rules
 
 - Run page skills in order: widgets when applicable, page implementation, then visual alignment when needed.
 - Keep the KX13 site accessible at the URL supplied to the skills.
@@ -294,12 +294,12 @@ newPageUrl: http://localhost:60444/en-us/home
 
 ## Scope and limitations
 
-The plugin assists with the content and live-site portions of the [upgrade workflow](#upgrade-workflow). The following areas are not automated:
+The plugin assists with the content and live site portions of the [upgrade workflow](#upgrade-workflow). The following areas are not automated:
 
 - **Commerce storefront**: checkout/cart/shipping/payment code, product catalog modeling, and storefront UI. The underlying Migration Tool now migrates customers and orders (added in January 2026 per [Plan your strategy for migrating features](https://docs.kentico.com/x/plan_your_strategy_for_migrating_features_guides#digital-commerce)). `migrate-content-appsettings` can emit the relevant settings when you explicitly opt into commerce migration. Otherwise, the skill omits `CommerceConfiguration` per its content-only default.
 - **Marketing**: marketing automation, contact groups, personas, A/B testing, social marketing, and email marketing. See the [feature matrix](https://docs.kentico.com/x/plan_your_strategy_for_migrating_features_guides#activities-and-digital-marketing) for which entities are out of scope.
 - **Search**: not migrated. Pick one of [Lucene](https://github.com/Kentico/xperience-by-kentico-lucene), [Azure AI Search](https://github.com/Kentico/xperience-by-kentico-azure-ai-search), or [Algolia](https://github.com/Kentico/xperience-by-kentico-algolia) and integrate manually per [Adjust your code and adapt your project](https://docs.kentico.com/x/migrate_your_code_guides#choose-a-search-integration).
-- **Custom-module UI pages**, KX13 alternative-form deltas, and ACLs. `migrate-content-classes` can route custom-table data into reusable content types via `ConvertClassesToContentHub` to skip the UI work entirely. Otherwise, the UI pages must be built manually per [Adjust your code and adapt your project](https://docs.kentico.com/x/migrate_your_code_guides#rehome-custom-tables).
+- **Custom-module UI pages**, KX13 alternative form deltas, and ACLs. `migrate-content-classes` can route custom table data into reusable content types via `ConvertClassesToContentHub` to skip the UI work entirely. Otherwise, the UI pages must be built manually per [Adjust your code and adapt your project](https://docs.kentico.com/x/migrate_your_code_guides#rehome-custom-tables).
 - **External sign-in information** (Facebook/Google/etc.) and the member registration/authentication code path itself. Basic member records migrate via the `--members` parameter. The live-site auth code must be rewritten to work with the new `Member` object type and ASP.NET Identity per [Adjust your code and adapt your project](https://docs.kentico.com/x/migrate_your_code_guides#alter-auth-and-user-management).
 - **Integration bus**, license keys, and `web.config`/`appsettings.json` settings – not migrated.
 - **Custom fields on system objects** such as `cms.user`, `cms.member`, or `cms.role` – outside the auditor's model export. The Migration Tool handles supported system-class fields through its custom-module migration, and anything beyond those needs custom migration logic.

--- a/plugins/kentico-kx13-migration/README.md
+++ b/plugins/kentico-kx13-migration/README.md
@@ -81,7 +81,7 @@ Place the source, target, Migration Tool, and audit output in one workspace:
 
 ---
 
-## Content-model audit
+## Content model audit
 
 `migrate-content-audit` runs the bundled .NET auditor against the KX13 database and exports the source model as JSON plus a Markdown report. Use its output as the input to `migrate-content-plan`. The auditor captures the content model and the references between its parts, and it migrates nothing.
 
@@ -227,7 +227,7 @@ These skills migrate the live-site foundation and presentation code, once conten
 
 Start the KX13 application or provide an accessible URL. Leave the XbyK application stopped unless a skill starts it for validation.
 
-### Codebase-migration skill sequence
+### Codebase migration skill sequence
 
 | Order | Skill | Outcome |
 |---|---|---|

--- a/plugins/kentico-project-lifecycle/README.md
+++ b/plugins/kentico-project-lifecycle/README.md
@@ -58,7 +58,7 @@ Pass the version when you need a known target, such as the version another envir
 
 ### Configure a scoped deployment
 
-The skill rebuilds `repository.config` for the changes you select. For restoring the package on the target environment, see [Deploy to the SaaS environment](https://docs.kentico.com/x/IgKQC).
+The skill rebuilds `repository.config` for the changes you select. To learn more about restoring the CD data, see [Restore the CD repository to the database](https://docs.kentico.com/documentation/developers-and-admins/ci-cd/continuous-deployment#restore-the-cd-repository-to-the-database). If preparing a package for restoring in a SaaS environment, see [Deploy to the SaaS environment](https://docs.kentico.com/x/IgKQC).
 
 ```text
 /cd-repository-configure

--- a/plugins/kentico-web-development/README.md
+++ b/plugins/kentico-web-development/README.md
@@ -66,7 +66,7 @@ This sequence takes a design through a content model, the components that render
 4. Review the proposal, then ask the agent to apply the approved model and generate the model classes your code binds to.
 
    ```text
-   Create the approved content types, reusable field schemas, and 
+   Create the approved content types, reusable field schemas, and
    taxonomies in my local instance, then generate the model classes.
    Use the Management MCP server.
    ```

--- a/plugins/kentico-web-development/README.md
+++ b/plugins/kentico-web-development/README.md
@@ -134,11 +134,11 @@ Both of these prompts produce a working output. However, providing the agent wit
 
 Carefully review all generated output, paying particular attention to:
 
-**Generated content model** -- Unless given specific and detailed instructions, a content model generated from the provided design is the agent's best estimate that satisfies the existing constraints. Validate it against your editorial and governance requirements before adopting it fully into your codebase.
+**Generated content model** – Unless given specific and detailed instructions, a content model generated from the provided design is the agent's best estimate that satisfies the existing constraints. Validate it against your editorial and governance requirements before adopting it fully into your codebase.
 
-**Both Page Builder modes** -- A widget that renders correctly on the live site can still fail in the editor, where properties, inline editors, and empty states behave differently. Add the component to a page and test it in edit mode as well as on the live site.
+**Both Page Builder modes** – A widget that renders correctly on the live site can still fail in the editor, where properties, inline editors, and empty states behave differently. Add the component to a page and test it in edit mode as well as on the live site.
 
-**Retrieval under load** -- Linked-item depth, projection, and caching decisions look correct against development data and degrade against production volumes. Raising linked-items depth above zero is the usual cause. Before you accept a generated query, read [Reference - ContentRetriever API](https://docs.kentico.com/x/reference_content_retriever_api_xp).
+**Retrieval under load** – Linked-item depth, projection, and caching decisions may look correct against development data, but degrade against production volumes. Raising linked-items depth above zero is the usual cause. Before you accept a generated query, read [Reference - ContentRetriever API](https://docs.kentico.com/x/reference_content_retriever_api_xp).
 
 ## Customize
 


### PR DESCRIPTION
## Summary

Minor documentation review changes of the repo revamp done in https://github.com/Kentico/xperience-by-kentico-kenticopilot/pull/40, and of the new automation skills.

## Following the conventions

- [x] The resource targets **Kentico Xperience developers** and is meant to be invoked by an AI assistant (not aimed at marketing, sales, or support).
- [x] The resource does **not** duplicate the Kentico documentation — it links the relevant docs pages and adds context instead.
- [x] Plugin and marketplace versions are bumped per the [versioning rules](https://github.com/Kentico/xperience-by-kentico-kenticopilot/blob/main/docs/Contributing-Setup.md#versioning-the-marketplace-manifests) — any plugin change bumps the marketplace version at least by a patch, and both marketplace files match.
